### PR TITLE
Feat: 커뮤니티 게시글 상세 페이지 및 댓글 (작성, 목록), 북마크, 좋아요 기능 구현

### DIFF
--- a/src/app/community/post/[id]/page.tsx
+++ b/src/app/community/post/[id]/page.tsx
@@ -1,5 +1,10 @@
-import { getPostDetailById } from "@/components/domains/postDetail/postDetail.helpers";
+import { cookies } from "next/headers";
+import {
+  getPostDetailById,
+  getPostDetailStatusById,
+} from "@/components/domains/postDetail/postDetail.helpers";
 import PageClient from "@/components/domains/postDetail/PageClient";
+import { getCommentsByPostId } from "@/components/domains/postDetail/commentSection/comment.helper";
 
 export default async function Page({
   params,
@@ -7,16 +12,32 @@ export default async function Page({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  const result = await getPostDetailById(id);
+  const cookieStore = cookies();
 
-  if (!result.success || !result.data) {
+  const requestHeaders = {
+    Cookie: cookieStore.toString(),
+  };
+  try {
+    const [postResult, postStatusResult, commentsResult] = await Promise.all([
+      getPostDetailById(id, requestHeaders),
+      getPostDetailStatusById(id, requestHeaders),
+      getCommentsByPostId(id),
+    ]);
+
     return (
-      <div>게시글을 불러오는 데 실패했거나, 존재하지 않는 게시글입니다.</div>
+      <>
+        <PageClient
+          postDetail={postResult.data}
+          postStatus={postStatusResult.data}
+          initialComments={commentsResult.data || []}
+        />
+      </>
+    );
+  } catch (error) {
+    return (
+      <div className="flex flex-col items-center justify-center h-screen">
+        게시글을 불러오는 데 실패했거나, 존재하지 않는 게시글입니다.
+      </div>
     );
   }
-  return (
-    <>
-      <PageClient postDetail={result.data} />
-    </>
-  );
 }

--- a/src/app/community/post/[id]/page.tsx
+++ b/src/app/community/post/[id]/page.tsx
@@ -34,6 +34,7 @@ export default async function Page({
       </>
     );
   } catch (error) {
+    console.error("Error fetching post details:", error);
     return (
       <div className="flex flex-col items-center justify-center h-screen">
         게시글을 불러오는 데 실패했거나, 존재하지 않는 게시글입니다.

--- a/src/components/commons/comment/index.tsx
+++ b/src/components/commons/comment/index.tsx
@@ -29,7 +29,7 @@ export default function Comment({
         placeholder={placeholder || COMMENT_PLACEHOLDERS[type]}
         value={inputValue}
         onChange={handleChange}
-        rows={1}
+        rows={5}
       />
       <span
         className={`absolute bottom-5 right-5 text-xs ${

--- a/src/components/domains/community/PageClient.tsx
+++ b/src/components/domains/community/PageClient.tsx
@@ -11,9 +11,9 @@ import {
   getUniquePostList,
 } from "./community.helpers";
 import { TPostCategory } from "@/lib/queries/community/postQueries";
+import { PostResponse } from "@/lib/hono/schemas/community.schema";
 import { useInfiniteScroll } from "@/lib/hooks/useInfinityScroll";
 import { Option, TSortBy } from "@/lib/constants/options";
-import { PostResponse } from "@/lib/hono/schemas/community.schema";
 
 export default function PageClient() {
   const router = useRouter();
@@ -80,9 +80,8 @@ export default function PageClient() {
   }, [searchKeyword]);
 
   const { data, isLoading, moreRef, isIdle } =
-    useInfiniteScroll<PostResponse[]>(fetcher);
-
-  const uniquePostData = useMemo(() => getUniquePostList(data.flat()), [data]);
+    useInfiniteScroll<PostResponse>(fetcher);
+  const uniquePostData = useMemo(() => getUniquePostList(data), [data]);
 
   return (
     <div className="px-4 w-full flex flex-col  gap-5">

--- a/src/components/domains/community/community.helpers.ts
+++ b/src/components/domains/community/community.helpers.ts
@@ -20,7 +20,7 @@ type FetchCommunityPostListParams = {
 
 async function fetchCommunityPostList(
   params: FetchCommunityPostListParams
-): Promise<SearchResponse<PostResponse[]>> {
+): Promise<SearchResponse<PostResponse>> {
   try {
     const queryParams = new URLSearchParams();
 
@@ -41,9 +41,10 @@ async function fetchCommunityPostList(
     queryParams.append("limit", "12");
 
     const response = await fetch(
-      `${API_BASE_URL}/posts?${queryParams.toString()}`,
+      `${API_BASE_URL}/community/posts?${queryParams.toString()}`,
       { method: "GET", next: { revalidate: 300 } }
     );
+
     if (!response.ok) {
       const errorData = await response
         .json()
@@ -52,12 +53,8 @@ async function fetchCommunityPostList(
         errorData.message || `Failed to fetch data: ${response.status}`
       );
     }
-    const result = await response.json();
-    return {
-      data: result.data,
-      nextCursor: result.nextCursor,
-      totalCount: result.totalCount,
-    };
+    const { data } = await response.json();
+    return data;
   } catch (error) {
     console.error("Error fetching community post list:", error);
     throw error;

--- a/src/components/domains/postDetail/PageClient.tsx
+++ b/src/components/domains/postDetail/PageClient.tsx
@@ -19,7 +19,7 @@ export default function PageClient({
   initialComments,
 }: IPostDetailPageClientProps) {
   const { content, ...postDetailHeader } = postDetail;
-  console.log(postDetail.isAuthor);
+
   return (
     <article>
       <PostDetailHeader postStatus={postStatus} {...postDetailHeader} />

--- a/src/components/domains/postDetail/PageClient.tsx
+++ b/src/components/domains/postDetail/PageClient.tsx
@@ -1,21 +1,38 @@
-import { TPostDetail } from "@/lib/queries/community/postQueries";
 import CommentSection from "./commentSection";
 import PostContent from "./content";
 import PostDetailHeader from "./header";
+import { CommentResponse } from "@/lib/hono/schemas/comment.schema";
+import {
+  PostDetailResponse,
+  PostStatusResponse,
+} from "@/lib/hono/schemas/community.schema";
 
 interface IPostDetailPageClientProps {
-  postDetail: TPostDetail;
+  postDetail: PostDetailResponse;
+  postStatus: PostStatusResponse;
+  initialComments: CommentResponse[] | [];
 }
 
-export default function PageClient({ postDetail }: IPostDetailPageClientProps) {
-  console.log("PostDetailPageClient", postDetail);
-  const { content, isAuthor, ...postDetailHeader } = postDetail;
-
+export default function PageClient({
+  postDetail,
+  postStatus,
+  initialComments,
+}: IPostDetailPageClientProps) {
+  const { content, ...postDetailHeader } = postDetail;
+  console.log(postDetail.isAuthor);
   return (
     <article>
-      <PostDetailHeader isAuthor={isAuthor} {...postDetailHeader} />
-      <PostContent content={content} isAuthor={isAuthor} relatedPerfumes={[]} />
-      <CommentSection />
+      <PostDetailHeader postStatus={postStatus} {...postDetailHeader} />
+      <PostContent
+        content={content}
+        isAuthor={postDetail.isAuthor}
+        relatedPerfumes={[]}
+      />
+      <CommentSection
+        postId={postDetail.id}
+        comments={initialComments}
+        totalCommentCount={postStatus.commentCount}
+      />
     </article>
   );
 }

--- a/src/components/domains/postDetail/commentSection/comment.helper.ts
+++ b/src/components/domains/postDetail/commentSection/comment.helper.ts
@@ -1,0 +1,72 @@
+import {
+  CommentResponse,
+  CreateCommentBody,
+  CreateCommentPayload,
+} from "@/lib/hono/schemas/comment.schema";
+import { ApiSuccessResponse } from "@/lib/hono/utils/response.constants";
+
+const API_BASE_URL = "http://localhost:3000/api/v1";
+
+export async function createNewComment(
+  postId: string,
+  commentData: CreateCommentBody
+): Promise<ApiSuccessResponse<CreateCommentPayload>> {
+  try {
+    const response = await fetch(`${API_BASE_URL}/comments/${postId}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(commentData),
+    });
+    if (!response.ok) {
+      const errorData = await response
+        .json()
+        .catch(() => ({ error: response.statusText }));
+      throw new Error(
+        errorData.message || `Failed to fetch data: ${response.status}`
+      );
+    }
+    const result = await response.json();
+    return result;
+  } catch (error) {
+    console.error("Error creating new comment:", error);
+    throw error;
+  }
+}
+
+export async function getCommentsByPostId(
+  postId: string
+): Promise<ApiSuccessResponse<CommentResponse[]>> {
+  try {
+    const response = await fetch(`${API_BASE_URL}/comments/${postId}`, {
+      method: "GET",
+      cache: "no-store",
+    });
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error("서버 응답 오류:", {
+        status: response.status,
+        statusText: response.statusText,
+        body: errorText,
+      });
+      let errorData;
+      try {
+        errorData = JSON.parse(errorText);
+      } catch {
+        errorData = {
+          error: `HTTP ${response.status}: ${response.statusText}`,
+        };
+      }
+
+      throw new Error(
+        errorData.error || `Failed to fetch data: ${response.status}`
+      );
+    }
+    const result = await response.json();
+    return result;
+  } catch (error) {
+    console.error("Error fetching comments:", error);
+    throw error;
+  }
+}

--- a/src/components/domains/postDetail/commentSection/comment/CommentForm.tsx
+++ b/src/components/domains/postDetail/commentSection/comment/CommentForm.tsx
@@ -5,38 +5,48 @@ import { ButtonOutlinedPrimaryLFit } from "@/components/commons/button/ButtonOut
 import Comment from "@/components/commons/comment";
 import { useState } from "react";
 import { ICommentFormProps } from "./postComment.types";
+import { createNewComment } from "../comment.helper";
+import { useRouter } from "next/navigation";
 
 export default function CommentForm({
   type,
   value,
   commentId,
-  onSubmit,
+  onSuccess,
+  postId,
 }: ICommentFormProps) {
   const [inputValue, setInputValue] = useState(value || "");
-
+  const router = useRouter(); // 댓글api 커서 추가시 수정 예정.
   const onChange = (inputValue: string) => {
     setInputValue(inputValue);
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!inputValue.trim()) return;
+    try {
+      switch (type) {
+        case "create":
+          await createNewComment(postId, { content: inputValue });
+          break;
+        case "reply":
+          await createNewComment(postId, {
+            content: inputValue,
+            parentId: commentId,
+          });
+          router.refresh();
+          break;
+        case "edit":
+          alert("댓글 id:" + commentId + "댓글 수정: " + inputValue);
+          break;
+      }
 
-    switch (type) {
-      case "create":
-        alert("댓글 작성: " + inputValue);
-
-        break;
-      case "reply":
-        alert("댓글 id:" + commentId + "답글 작성: " + inputValue);
-        onSubmit?.();
-        break;
-      case "edit":
-        alert("댓글 id:" + commentId + "댓글 수정: " + inputValue);
-        onSubmit?.();
-        break;
+      setInputValue("");
+      onSuccess?.();
+    } catch (error) {
+      console.error("댓글 작성 실패:", error);
+      alert("오류가 발생했습니다. 다시 시도해 주세요.");
     }
-    setInputValue("");
   };
 
   return (

--- a/src/components/domains/postDetail/commentSection/comment/CommentIList.tsx
+++ b/src/components/domains/postDetail/commentSection/comment/CommentIList.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { ButtonFilledGrayLFixed } from "@/components/commons/button/ButtonFilled";
-import CommentIListItem from "./CommentListItem";
+import CommentListItem from "./CommentListItem";
 import { ICommentIListProps, TCommentActionState } from "./postComment.types";
 import { useState } from "react";
 import ArrowIcon from "@/components/commons/icons/arrowIcon";
 
-export default function CommentIList({ commentList }: ICommentIListProps) {
+export default function CommentList({ commentList }: ICommentIListProps) {
   const [editingCommentId, setEditingCommentId] = useState<string | null>(null);
   const [replyingCommentId, setReplyingCommentId] = useState<string | null>(
     null
@@ -23,7 +23,7 @@ export default function CommentIList({ commentList }: ICommentIListProps) {
       <ul className="flex flex-col w-full">
         {commentList.length > 0 &&
           commentList.map((comment) => (
-            <CommentIListItem
+            <CommentListItem
               key={comment.id}
               commentActionState={commentActionState}
               comment={comment}

--- a/src/components/domains/postDetail/commentSection/comment/CommentListItem.tsx
+++ b/src/components/domains/postDetail/commentSection/comment/CommentListItem.tsx
@@ -1,16 +1,21 @@
 import { ActionItem, Actions } from "@/components/commons/actions";
 import { CommentAuthInfo, CommentUserProfile } from "./CommentAuthInfo";
-import { TComment, TCommentActionState } from "./postComment.types";
+import { TCommentActionState } from "./postComment.types";
 import CommentForm from "./CommentForm";
 import ReplyIcon from "./ReplyIcon";
+import {
+  CommentReplyResponse,
+  CommentResponse,
+} from "@/lib/hono/schemas/comment.schema";
+import { useUserStore } from "@/lib/stores/useUserStore";
 
-export default function CommentIListItem({
+export default function CommentListItem({
   commentActionState,
   comment,
   isReplyType = false,
 }: {
   commentActionState: TCommentActionState;
-  comment: TComment;
+  comment: CommentResponse | CommentReplyResponse;
   isReplyType?: boolean;
 }) {
   const {
@@ -19,12 +24,23 @@ export default function CommentIListItem({
     replyingCommentId,
     setReplyingCommentId,
   } = commentActionState;
-
-  const { id, authInfo, isAuthor, createdAt, content, replies } = comment;
+  const { user } = useUserStore();
+  const { id, author, createdAt, content, postId } = comment;
+  const isAuthor = author.id === user?.id;
   const isEditing = editingCommentId === id;
   const isReplying = replyingCommentId === id;
   const isAnyCommentBeingEdited = editingCommentId !== null;
   const isAnyCommentBeingReplied = replyingCommentId !== null;
+  const userActions: ActionItem[] = [
+    {
+      type: "reply",
+      onClick: () => {
+        setEditingCommentId(null);
+        setReplyingCommentId(id);
+      },
+      disabled: isAnyCommentBeingEdited,
+    },
+  ];
 
   const authorActions: ActionItem[] = [
     {
@@ -42,17 +58,6 @@ export default function CommentIListItem({
     },
   ];
 
-  const userActions: ActionItem[] = [
-    {
-      type: "reply",
-      onClick: () => {
-        setEditingCommentId(null);
-        setReplyingCommentId(id);
-      },
-      disabled: isAnyCommentBeingEdited,
-    },
-  ];
-
   let actions: ActionItem[] = [];
 
   if (isEditing || isReplying) {
@@ -65,12 +70,15 @@ export default function CommentIListItem({
         },
       },
     ];
-  } else if (isAuthor) {
-    actions = authorActions;
-  } else if (!isReplyType) {
-    actions = userActions;
-  }
+  } else {
+    if (!isReplyType) {
+      actions.push(...userActions);
+    }
 
+    if (isAuthor) {
+      actions.push(...authorActions);
+    }
+  }
   return (
     <>
       <li>
@@ -79,8 +87,8 @@ export default function CommentIListItem({
           <article className="w-full flex flex-col gap-3">
             <div className="flex items-center justify-between">
               <CommentAuthInfo
-                author={authInfo.author}
-                profileImage={authInfo.profileImage}
+                author={author.nickname}
+                profileImage={author.imageUrl}
                 createdAt={createdAt}
               />
               {actions.length > 0 && !isReplying && (
@@ -92,7 +100,8 @@ export default function CommentIListItem({
                 type="edit"
                 value={content}
                 commentId={editingCommentId}
-                onSubmit={() => {
+                postId={postId}
+                onSuccess={() => {
                   setEditingCommentId(null);
                 }}
               />
@@ -105,33 +114,36 @@ export default function CommentIListItem({
         </div>
         <div className="divider-horizontal" />
       </li>
-      {replies &&
-        replies.length > 0 &&
-        replies.map((reply) => (
+      {"replies" in comment &&
+        comment.replies &&
+        comment.replies.length > 0 &&
+        comment.replies.map((reply) => (
           <ul key={reply.id}>
-            <CommentIListItem
+            <CommentListItem
               commentActionState={commentActionState}
               comment={reply}
               isReplyType
             />
           </ul>
         ))}
-      {isReplying && (
+
+      {isReplying && user && (
         <>
           <section className="flex gap-5 py-5">
             <ReplyIcon />
             <div className="w-full">
               <div className="mb-3 flex items-center justify-between">
                 <CommentUserProfile
-                  author={"로그인한 유저 닉네임"}
-                  profileImage={""}
+                  author={user.nickname}
+                  profileImage={user.imageUrl}
                 />
                 <Actions actions={actions} />
               </div>
               <CommentForm
                 type="reply"
+                postId={postId}
                 commentId={replyingCommentId}
-                onSubmit={() => setReplyingCommentId(null)}
+                onSuccess={() => setReplyingCommentId(null)}
               />
             </div>
           </section>

--- a/src/components/domains/postDetail/commentSection/comment/mockCommentList.ts
+++ b/src/components/domains/postDetail/commentSection/comment/mockCommentList.ts
@@ -1,152 +1,152 @@
-import { TComment } from "./postComment.types";
+// import { TComment } from "./postComment.types";
 
-export const mockCommentList: TComment[] = [
-  {
-    id: "1",
-    authInfo: {
-      author: "주현",
-      profileImage: "",
-    },
-    createdAt: "2025-04-25 09:12:00",
-    content: "정말 유익한 글이네요! 감사합니다.",
-    isAuthor: true,
-    replies: [
-      {
-        id: "1-1",
-        authInfo: {
-          author: "민수",
-          profileImage: "",
-        },
-        createdAt: "2025-04-25 09:13:00",
-        content: "저도 동의합니다!",
-        isAuthor: false,
-      },
-      {
-        id: "1-2",
-        authInfo: {
-          author: "지영",
-          profileImage: "",
-        },
-        createdAt: "2025-04-25 09:14:00",
-        content: "좋은 의견 감사합니다.",
-        isAuthor: false,
-      },
-    ],
-  },
-  {
-    id: "2",
-    authInfo: {
-      author: "민수",
-      profileImage: "",
-    },
-    createdAt: "2025-04-25 09:15:23",
-    content: "궁금했던 부분이 잘 설명되어 있어요.",
-    isAuthor: false,
-    replies: [
-      {
-        id: "2-1",
-        authInfo: {
-          author: "주현",
-          profileImage: "",
-        },
-        createdAt: "2025-04-25 09:16:00",
-        content: "도움이 되셨다니 다행입니다!",
-        isAuthor: true,
-      },
-    ],
-  },
-  {
-    id: "3",
-    authInfo: {
-      author: "지영",
-      profileImage: "",
-    },
-    createdAt: "2025-04-25 09:18:41",
-    content: "좋은 정보 감사합니다!",
-    isAuthor: false,
-    replies: [],
-  },
-  {
-    id: "4",
-    authInfo: {
-      author: "철수",
-      profileImage: "",
-    },
-    createdAt: "2025-04-25 09:21:05",
-    content: "도움이 많이 됐어요.",
-    isAuthor: false,
-  },
-  {
-    id: "5",
-    authInfo: {
-      author: "수진",
-      profileImage: "",
-    },
-    createdAt: "2025-04-25 09:23:17",
-    content: "다음 글도 기대할게요!",
-    isAuthor: false,
-    replies: [
-      {
-        id: "5-1",
-        authInfo: {
-          author: "예린",
-          profileImage: "",
-        },
-        createdAt: "2025-04-25 09:24:00",
-        content: "저도 기대 중입니다 :)",
-        isAuthor: false,
-      },
-    ],
-  },
-  // 나머지 댓글들은 replies 없이 그대로 두셔도 됩니다.
-  {
-    id: "6",
-    authInfo: {
-      author: "영희",
-      profileImage: "",
-    },
-    createdAt: "2025-04-25 09:25:33",
-    content: "질문이 있는데 답변 부탁드려요.",
-    isAuthor: false,
-  },
-  {
-    id: "7",
-    authInfo: {
-      author: "동현",
-      profileImage: "",
-    },
-    createdAt: "2025-04-25 09:28:11",
-    content: "정성스러운 답변 감사합니다.",
-    isAuthor: false,
-  },
-  {
-    id: "8",
-    authInfo: {
-      author: "하늘",
-      profileImage: "",
-    },
-    createdAt: "2025-04-25 09:31:02",
-    content: "이 부분이 특히 인상적이었어요.",
-    isAuthor: false,
-  },
-  {
-    id: "9",
-    authInfo: {
-      author: "지훈",
-      profileImage: "",
-    },
-    createdAt: "2025-04-25 09:34:55",
-    content: "공감되는 내용이 많네요.",
-    isAuthor: false,
-  },
-  {
-    id: "10",
-    authInfo: {
-      author: "예린",
-      profileImage: "",
-    },
-    createdAt: "2025-04-25 09:38:27",
-    content: "덕분에 많이 배웠습니다!",
-    isAuthor: false,
-  },
-];
+// export const mockCommentList: TComment[] = [
+//   {
+//     id: "1",
+//     authInfo: {
+//       author: "주현",
+//       profileImage: "",
+//     },
+//     createdAt: "2025-04-25 09:12:00",
+//     content: "정말 유익한 글이네요! 감사합니다.",
+//     isAuthor: true,
+//     replies: [
+//       {
+//         id: "1-1",
+//         authInfo: {
+//           author: "민수",
+//           profileImage: "",
+//         },
+//         createdAt: "2025-04-25 09:13:00",
+//         content: "저도 동의합니다!",
+//         isAuthor: false,
+//       },
+//       {
+//         id: "1-2",
+//         authInfo: {
+//           author: "지영",
+//           profileImage: "",
+//         },
+//         createdAt: "2025-04-25 09:14:00",
+//         content: "좋은 의견 감사합니다.",
+//         isAuthor: false,
+//       },
+//     ],
+//   },
+//   {
+//     id: "2",
+//     authInfo: {
+//       author: "민수",
+//       profileImage: "",
+//     },
+//     createdAt: "2025-04-25 09:15:23",
+//     content: "궁금했던 부분이 잘 설명되어 있어요.",
+//     isAuthor: false,
+//     replies: [
+//       {
+//         id: "2-1",
+//         authInfo: {
+//           author: "주현",
+//           profileImage: "",
+//         },
+//         createdAt: "2025-04-25 09:16:00",
+//         content: "도움이 되셨다니 다행입니다!",
+//         isAuthor: true,
+//       },
+//     ],
+//   },
+//   {
+//     id: "3",
+//     authInfo: {
+//       author: "지영",
+//       profileImage: "",
+//     },
+//     createdAt: "2025-04-25 09:18:41",
+//     content: "좋은 정보 감사합니다!",
+//     isAuthor: false,
+//     replies: [],
+//   },
+//   {
+//     id: "4",
+//     authInfo: {
+//       author: "철수",
+//       profileImage: "",
+//     },
+//     createdAt: "2025-04-25 09:21:05",
+//     content: "도움이 많이 됐어요.",
+//     isAuthor: false,
+//   },
+//   {
+//     id: "5",
+//     authInfo: {
+//       author: "수진",
+//       profileImage: "",
+//     },
+//     createdAt: "2025-04-25 09:23:17",
+//     content: "다음 글도 기대할게요!",
+//     isAuthor: false,
+//     replies: [
+//       {
+//         id: "5-1",
+//         authInfo: {
+//           author: "예린",
+//           profileImage: "",
+//         },
+//         createdAt: "2025-04-25 09:24:00",
+//         content: "저도 기대 중입니다 :)",
+//         isAuthor: false,
+//       },
+//     ],
+//   },
+//   // 나머지 댓글들은 replies 없이 그대로 두셔도 됩니다.
+//   {
+//     id: "6",
+//     authInfo: {
+//       author: "영희",
+//       profileImage: "",
+//     },
+//     createdAt: "2025-04-25 09:25:33",
+//     content: "질문이 있는데 답변 부탁드려요.",
+//     isAuthor: false,
+//   },
+//   {
+//     id: "7",
+//     authInfo: {
+//       author: "동현",
+//       profileImage: "",
+//     },
+//     createdAt: "2025-04-25 09:28:11",
+//     content: "정성스러운 답변 감사합니다.",
+//     isAuthor: false,
+//   },
+//   {
+//     id: "8",
+//     authInfo: {
+//       author: "하늘",
+//       profileImage: "",
+//     },
+//     createdAt: "2025-04-25 09:31:02",
+//     content: "이 부분이 특히 인상적이었어요.",
+//     isAuthor: false,
+//   },
+//   {
+//     id: "9",
+//     authInfo: {
+//       author: "지훈",
+//       profileImage: "",
+//     },
+//     createdAt: "2025-04-25 09:34:55",
+//     content: "공감되는 내용이 많네요.",
+//     isAuthor: false,
+//   },
+//   {
+//     id: "10",
+//     authInfo: {
+//       author: "예린",
+//       profileImage: "",
+//     },
+//     createdAt: "2025-04-25 09:38:27",
+//     content: "덕분에 많이 배웠습니다!",
+//     isAuthor: false,
+//   },
+// ];

--- a/src/components/domains/postDetail/commentSection/comment/postComment.types.ts
+++ b/src/components/domains/postDetail/commentSection/comment/postComment.types.ts
@@ -1,6 +1,8 @@
+import { CommentResponse } from "@/lib/hono/schemas/comment.schema";
+
 export interface ICommentAuthProfileProps {
   author: string;
-  profileImage?: string;
+  profileImage?: string | null;
 }
 
 export interface ICommentAuthInfoProps extends ICommentAuthProfileProps {
@@ -13,11 +15,11 @@ export type TComment = {
   content: string;
   createdAt: string;
   isAuthor: boolean;
-  replies?: TComment[];
+  replies?: CommentResponse[];
 };
 
 export interface ICommentIListProps {
-  commentList: TComment[];
+  commentList: CommentResponse[];
 }
 
 export interface ICommentFormProps {
@@ -25,7 +27,8 @@ export interface ICommentFormProps {
   value?: string;
   authInfo?: ICommentAuthInfoProps;
   commentId?: string;
-  onSubmit?: () => void;
+  postId: string;
+  onSuccess?: () => void;
   onCancel?: () => void;
 }
 

--- a/src/components/domains/postDetail/commentSection/index.tsx
+++ b/src/components/domains/postDetail/commentSection/index.tsx
@@ -1,16 +1,32 @@
+"use client";
+import { CommentResponse } from "@/lib/hono/schemas/comment.schema";
 import CommentForm from "./comment/CommentForm";
 import CommentIList from "./comment/CommentIList";
-import { mockCommentList } from "./comment/mockCommentList";
 
-export default function CommentSection() {
-  const count = 10;
+import { useRouter } from "next/navigation";
+
+interface ICommentSectionProps {
+  postId: string;
+  comments: CommentResponse[] | [];
+  totalCommentCount: number;
+}
+export default function CommentSection({
+  postId,
+  comments,
+  totalCommentCount,
+}: ICommentSectionProps) {
+  const router = useRouter();
   return (
     <section className="px-4">
       <h2 className="text-title-2 tablet:text-headline-2 font-semibold text-black-100">
-        댓글 {count}
+        댓글 {totalCommentCount}
       </h2>
-      <CommentForm type="create" />
-      <CommentIList commentList={mockCommentList} />
+      <CommentForm
+        type="create"
+        postId={postId}
+        onSuccess={() => router.refresh()} // 댓글 커서 추가하면 수정 예정.
+      />
+      {comments.length > 0 && <CommentIList commentList={comments} />}
     </section>
   );
 }

--- a/src/components/domains/postDetail/header/PostInteractions.tsx
+++ b/src/components/domains/postDetail/header/PostInteractions.tsx
@@ -28,8 +28,6 @@ export default function PostInteractions({
   const [isLiked, setIsLiked] = useState(initialIsLiked);
   const [isBookmarked, setIsBookmarked] = useState(initialIsBookmarked);
 
-  console.log(initialIsBookmarked);
-
   const handleLikeToggle = async () => {
     if (!user) {
       alert("로그인이 필요한 기능입니다.");

--- a/src/components/domains/postDetail/header/PostInteractions.tsx
+++ b/src/components/domains/postDetail/header/PostInteractions.tsx
@@ -1,43 +1,79 @@
 "use client";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { BookmarkIcon } from "@/components/commons/interactions/icons/BookmarkIcon";
 import { LikeIcon } from "@/components/commons/interactions/icons/LikeIcon";
 import { ShareIcon } from "@/components/commons/interactions/icons/ShareIcon";
 import { Interactions } from "@/components/commons/interactions";
-import { TPostDetail } from "@/lib/queries/community/postQueries";
+import { useRouter } from "next/navigation";
+import {
+  toggleLikedPostById,
+  toggleBookmarkedPostById,
+} from "../postDetail.helpers";
+import { useUserStore } from "@/lib/stores/useUserStore";
 
-type IPostInteractionsProps = Pick<TPostDetail, "isLiked" | "bookmarkInfo">;
+interface IPostInteractionsProps {
+  initialIsLiked: boolean;
+  initialIsBookmarked: boolean;
+  postId: string;
+}
 
 export default function PostInteractions({
-  isLiked,
-  bookmarkInfo,
+  initialIsLiked,
+  initialIsBookmarked,
+  postId,
 }: IPostInteractionsProps) {
-  const [activeStates, setActiveStates] = useState({
-    like: isLiked,
-    bookmark: bookmarkInfo.isBookmarked,
-  });
+  const router = useRouter();
+  const { user, isLoading } = useUserStore();
 
-  const toggle = (key: keyof typeof activeStates) => {
-    setActiveStates((prev) => ({
-      ...prev,
-      [key]: !prev[key],
-    }));
+  const [isLiked, setIsLiked] = useState(initialIsLiked);
+  const [isBookmarked, setIsBookmarked] = useState(initialIsBookmarked);
+
+  console.log(initialIsBookmarked);
+
+  const handleLikeToggle = async () => {
+    if (!user) {
+      alert("로그인이 필요한 기능입니다.");
+      return;
+    }
+    setIsLiked((prev) => !prev);
+    try {
+      await toggleLikedPostById(postId);
+      router.refresh();
+    } catch (error) {
+      setIsLiked((prev) => !prev);
+      alert("좋아요 처리실패.");
+    }
+  };
+
+  const handleBookmarkToggle = async () => {
+    if (!user) {
+      alert("로그인이 필요한 기능입니다.");
+      return;
+    }
+    setIsBookmarked((prev) => !prev);
+    try {
+      await toggleBookmarkedPostById(postId);
+      router.refresh();
+    } catch (error) {
+      setIsBookmarked((prev) => !prev);
+      alert("북마크 처리 실패.");
+    }
   };
 
   const interactions = [
     {
       type: "like",
-      isActive: activeStates.like,
-      onClick: () => toggle("like"),
+      isActive: isLiked,
+      onClick: handleLikeToggle,
       label: "좋아요",
-      icon: <LikeIcon isActive={activeStates.like} />,
+      icon: <LikeIcon isActive={isLiked} />,
     },
     {
       type: "bookmark",
-      isActive: activeStates.bookmark,
-      onClick: () => toggle("bookmark"),
+      isActive: isBookmarked,
+      onClick: handleBookmarkToggle,
       label: "북마크",
-      icon: <BookmarkIcon isActive={activeStates.like} />,
+      icon: <BookmarkIcon isActive={isBookmarked} />,
     },
     {
       type: "share",
@@ -46,6 +82,13 @@ export default function PostInteractions({
       icon: <ShareIcon />,
     },
   ];
+
+  useEffect(() => {
+    if (!isLoading && !user) {
+      setIsLiked(false);
+      setIsBookmarked(false);
+    }
+  }, [user, isLoading]);
 
   return (
     <>

--- a/src/components/domains/postDetail/header/PostInteractions.tsx
+++ b/src/components/domains/postDetail/header/PostInteractions.tsx
@@ -40,6 +40,7 @@ export default function PostInteractions({
     } catch (error) {
       setIsLiked((prev) => !prev);
       alert("좋아요 처리실패.");
+      console.error("좋아요 처리 실패:", error);
     }
   };
 
@@ -55,6 +56,7 @@ export default function PostInteractions({
     } catch (error) {
       setIsBookmarked((prev) => !prev);
       alert("북마크 처리 실패.");
+      console.error("북마크 처리 실패:", error);
     }
   };
 

--- a/src/components/domains/postDetail/header/index.tsx
+++ b/src/components/domains/postDetail/header/index.tsx
@@ -3,22 +3,24 @@ import { InfoType } from "@/components/commons/author/author.types";
 import BoardChip from "@/components/commons/chip/BoardChip";
 import PostInteractions from "./PostInteractions";
 import PostActions from "./PostActions";
-import { TPostDetail } from "@/lib/queries/community/postQueries";
+import {
+  PostDetailResponse,
+  PostStatusResponse,
+} from "@/lib/hono/schemas/community.schema";
 
-type IPostDetailHeaderProps = Omit<TPostDetail, "content">;
+type PostDetailHeaderProps = Omit<PostDetailResponse, "content"> & {
+  postStatus: PostStatusResponse;
+};
 
-export default function PostDetailHeader(props: IPostDetailHeaderProps) {
+export default function PostDetailHeader(props: PostDetailHeaderProps) {
   const {
     author,
     title,
     createdAt,
     isAuthor,
-    isLiked,
-    bookmarkInfo,
     category,
-    viewCount,
-    likeCount,
-    commentCount,
+    id: postId,
+    postStatus: { isLiked, viewCount, commentCount, likeCount, isBookmarked },
   } = props;
   const postReactionInfo: InfoType = {
     type: "post",
@@ -28,11 +30,16 @@ export default function PostDetailHeader(props: IPostDetailHeaderProps) {
       { type: "Like", count: likeCount },
     ],
   };
+  console.log(isAuthor);
   return (
     <header className="mobile:mt-10 pc:mt-[60px] px-4">
       <div className="flex item-center justify-between">
         <BoardChip type={category} />
-        <PostInteractions isLiked={isLiked} bookmarkInfo={bookmarkInfo} />
+        <PostInteractions
+          initialIsLiked={isLiked}
+          initialIsBookmarked={isBookmarked}
+          postId={postId}
+        />
       </div>
       <h1 className="mt-5 mb-4 tablet:mb-5 text-title-1 tablet:text-headline-3 font-semibold text-black-100">
         {title}

--- a/src/components/domains/postDetail/postDetail.helpers.ts
+++ b/src/components/domains/postDetail/postDetail.helpers.ts
@@ -1,43 +1,171 @@
-import { TPostDetail } from "@/lib/queries/community/postQueries";
-import { cookies } from "next/headers";
+import {
+  PostDetailResponse,
+  PostResponse,
+  PostStatusResponse,
+} from "@/lib/hono/schemas/community.schema";
+import { ApiSuccessResponse } from "@/lib/hono/utils/response.constants";
 
 const API_BASE_URL = "http://localhost:3000/api";
-
-type TPostDetailApiResponse = {
-  success: boolean;
-  data: TPostDetail | null;
-  message?: string;
-};
+const COMMUNITY_URL = `${API_BASE_URL}/v1/community/posts`;
 
 export async function getPostDetailById(
-  postId: string
-): Promise<TPostDetailApiResponse> {
-  const cookieStore = await cookies();
-
+  postId: string,
+  headers: HeadersInit
+): Promise<ApiSuccessResponse<PostDetailResponse>> {
   try {
-    const response = await fetch(`${API_BASE_URL}/community/post/${postId}`, {
-      cache: "no-store",
-      headers: {
-        Cookie: cookieStore.toString(),
-      },
+    const response = await fetch(`${COMMUNITY_URL}/${postId}`, {
+      method: "GET",
+      next: { revalidate: 300 },
+      headers: headers,
     });
 
-    const data = await response.json();
     if (!response.ok) {
-      console.error(`Error fetching post ${postId}:`, data.message);
-      return {
-        data: null,
-        success: false,
-        message: data.message || "서버 내부 오류가 발생했습니다.",
-      };
+      const errorText = await response.text();
+      console.error("서버 응답 오류:", {
+        status: response.status,
+        statusText: response.statusText,
+        body: errorText,
+      });
+
+      let errorData;
+      try {
+        errorData = JSON.parse(errorText);
+      } catch {
+        errorData = {
+          error: `HTTP ${response.status}: ${response.statusText}`,
+        };
+      }
+
+      throw new Error(
+        errorData.error || `Failed to fetch data: ${response.status}`
+      );
     }
-    return { data, success: response.ok };
+
+    const result = await response.json();
+    return result;
   } catch (error) {
     console.error(`Error fetching post ${postId}:`, error);
-    return {
-      data: null,
-      success: false,
-      message: "서버 내부 오류가 발생했습니다.",
-    };
+    throw error;
+  }
+}
+
+export async function getPostDetailStatusById(
+  postId: string,
+  headers: HeadersInit
+): Promise<ApiSuccessResponse<PostStatusResponse>> {
+  try {
+    const response = await fetch(`${COMMUNITY_URL}/${postId}/status`, {
+      method: "GET",
+      cache: "no-store",
+      headers: headers,
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error("서버 응답 오류:", {
+        status: response.status,
+        statusText: response.statusText,
+        body: errorText,
+      });
+
+      let errorData;
+      try {
+        errorData = JSON.parse(errorText);
+      } catch {
+        errorData = {
+          error: `HTTP ${response.status}: ${response.statusText}`,
+        };
+      }
+
+      throw new Error(
+        errorData.error || `Failed to fetch data: ${response.status}`
+      );
+    }
+
+    const result = await response.json();
+
+    return result;
+  } catch (error) {
+    console.error("Error fetching post status:", error);
+    throw error;
+  }
+}
+
+export async function toggleBookmarkedPostById(
+  postId: string
+): Promise<ApiSuccessResponse<PostResponse>> {
+  try {
+    const response = await fetch(`${COMMUNITY_URL}/${postId}/bookmark`, {
+      method: "POST",
+      cache: "no-store",
+    });
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error("서버 응답 오류:", {
+        status: response.status,
+        statusText: response.statusText,
+        body: errorText,
+      });
+
+      let errorData;
+      try {
+        errorData = JSON.parse(errorText);
+      } catch {
+        errorData = {
+          error: `HTTP ${response.status}: ${response.statusText}`,
+        };
+      }
+
+      throw new Error(
+        errorData.error || `Failed to fetch data: ${response.status}`
+      );
+    }
+
+    const result = await response.json();
+
+    return result;
+  } catch (error) {
+    console.error("Error fetching bookmarked posts:", error);
+    throw error;
+  }
+}
+
+export async function toggleLikedPostById(
+  postId: string
+): Promise<ApiSuccessResponse<PostResponse>> {
+  try {
+    const response = await fetch(`${COMMUNITY_URL}/${postId}/like`, {
+      method: "POST",
+      cache: "no-store",
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error("서버 응답 오류:", {
+        status: response.status,
+        statusText: response.statusText,
+        body: errorText,
+      });
+
+      let errorData;
+      try {
+        errorData = JSON.parse(errorText);
+      } catch {
+        errorData = {
+          error: `HTTP ${response.status}: ${response.statusText}`,
+        };
+      }
+
+      throw new Error(
+        errorData.error || `Failed to fetch data: ${response.status}`
+      );
+    }
+
+    const result = await response.json();
+
+    return result;
+  } catch (error) {
+    console.error("Error fetching liked posts:", error);
+    throw error;
   }
 }

--- a/src/lib/hono/middleware/auth.middleware.ts
+++ b/src/lib/hono/middleware/auth.middleware.ts
@@ -13,3 +13,16 @@ export const authMiddleware = createMiddleware<AppContext>(async (c, next) => {
 
   await next();
 });
+
+export const optionalAuthMiddleware = createMiddleware<AppContext>(
+  async (c, next) => {
+    const session = await getSession();
+
+    if (session && session.user) {
+      c.set("user", session.user);
+      c.set("session", session);
+    }
+
+    await next();
+  }
+);

--- a/src/lib/hono/routes/v1/community.handler.ts
+++ b/src/lib/hono/routes/v1/community.handler.ts
@@ -1,7 +1,10 @@
 import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 
 import type { AppContext } from "@/lib/hono/app";
-import { authMiddleware } from "@/lib/hono/middleware/auth.middleware";
+import {
+  authMiddleware,
+  optionalAuthMiddleware,
+} from "@/lib/hono/middleware/auth.middleware";
 import * as CommunityServices from "@/lib/hono/services/community.service";
 import * as CommunitySchemas from "@/lib/hono/schemas/community.schema";
 import { createStandardApiResponses } from "@/lib/hono/utils/createStandardApiResponses";
@@ -18,6 +21,8 @@ const communityApi = new OpenAPIHono<AppContext>();
 const authenticatedApi = new OpenAPIHono<AppContext>();
 
 authenticatedApi.use("*", authMiddleware);
+communityApi.use("/posts/:id", optionalAuthMiddleware);
+communityApi.use("/posts/:id/status", optionalAuthMiddleware);
 
 /**
  * @method GET
@@ -77,11 +82,51 @@ const getPostRoute = createRoute({
 
 communityApi.openapi(getPostRoute, async (c) => {
   const { id } = c.req.valid("param");
-  const post = await CommunityServices.getPostByIdService(id);
+  const user = c.get("user");
+  const post = await CommunityServices.getPostByIdService(id, user?.id);
   if (!post.success) {
     return apiNotFound(c, post.message);
   }
   return apiSuccess(c, post.data, "게시글을 성공적으로 불러왔습니다.");
+});
+
+/**
+ * @method GET
+ * @path /posts/{id}/status
+ * @summary 커뮤니티 게시글 상태 정보 조회
+ */
+const getPostStatusRoute = createRoute({
+  method: "get",
+  path: "/posts/{id}/status",
+  summary: "게시글 상태 정보 조회",
+  description:
+    "게시글의 카운트 정보(조회수, 좋아요, 댓글)와 현재 사용자의 좋아요/북마크 여부를 조회합니다.",
+  request: {
+    params: CommunitySchemas.PostIdParamSchema,
+  },
+  responses: createStandardApiResponses(
+    {
+      schema: CommunitySchemas.PostStatusResponseSchema,
+      description: "게시글 상태 정보",
+    },
+    ["404"]
+  ),
+  tags: ["Community"],
+});
+
+communityApi.openapi(getPostStatusRoute, async (c) => {
+  const { id } = c.req.valid("param");
+  const user = c.get("user");
+  const result = await CommunityServices.getPostStatusByIdService(id, user?.id);
+  if (!result.success) {
+    if (result.error === "NOT_FOUND") return apiNotFound(c, result.message);
+    return apiInternalError(c, result.message);
+  }
+  return apiSuccess(
+    c,
+    result.data,
+    "게시글 상태 정보를 성공적으로 불러왔습니다."
+  );
 });
 
 /**

--- a/src/lib/hono/schemas/comment.schema.ts
+++ b/src/lib/hono/schemas/comment.schema.ts
@@ -7,6 +7,8 @@ const ReplyResponseSchema = CommentSchema.extend({
     nickname: true,
     imageUrl: true,
   }),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime().nullable(),
 }).omit({ authorId: true });
 
 export const CommentResponseSchema = ReplyResponseSchema.extend({
@@ -28,6 +30,7 @@ export const PostIdParamSchema = z.object({
   postId: z.string().uuid("유효하지 않은 게시글 ID입니다."),
 });
 
+export type CommentReplyResponse = z.infer<typeof ReplyResponseSchema>;
 export type CommentResponse = z.infer<typeof CommentResponseSchema>;
 export type CreateCommentBody = z.infer<typeof CreateCommentBodySchema>;
 export type CreateCommentPayload = z.infer<typeof CreateCommentPayloadSchema>;

--- a/src/lib/hono/schemas/common.schema.ts
+++ b/src/lib/hono/schemas/common.schema.ts
@@ -15,6 +15,11 @@ export const PaginationSchema = z.object({
     .openapi({ example: 100, description: "총 아이템 수" }),
 });
 
+export const CursorPaginationSchema = z.object({
+  cursor: z.string().uuid("유효하지 않은 커서 ID입니다.").optional(),
+  limit: z.coerce.number().int().positive().default(12),
+});
+
 export const SuccessResponseSchema = (dataSchema: z.ZodType) =>
   z.object({
     success: z.literal(true),

--- a/src/lib/hono/schemas/community.schema.ts
+++ b/src/lib/hono/schemas/community.schema.ts
@@ -11,6 +11,8 @@ export const PostResponseSchema = PostSchema.extend({
     nickname: true,
     imageUrl: true,
   }),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime().nullable(),
 }).omit({
   userId: true,
   published: true,

--- a/src/lib/hono/schemas/community.schema.ts
+++ b/src/lib/hono/schemas/community.schema.ts
@@ -1,7 +1,7 @@
 import { z } from "@hono/zod-openapi";
 import PostSchema from "@zod/modelSchema/PostSchema";
 import UserSchema from "@zod/modelSchema/UserSchema";
-import { PaginationSchema } from "./common.schema";
+import { CursorPaginationSchema } from "./common.schema";
 import { PostCategory } from "@prisma/client";
 
 // API 응답용 스키마
@@ -17,12 +17,10 @@ export const PostResponseSchema = PostSchema.extend({
 });
 
 // 글 목록 조회 쿼리
-export const GetPostsQuerySchema = PaginationSchema.extend({
+export const GetPostsQuerySchema = CursorPaginationSchema.extend({
   q: z.string().optional(),
-  category: z.nativeEnum(PostCategory).default(PostCategory.FREEBOARD),
+  category: z.nativeEnum(PostCategory).optional(),
   sortBy: z.enum(["createdAt", "popular"]).default("createdAt"),
-  cursor: z.string().uuid("유효하지 않은 커서 ID입니다.").optional(),
-  limit: z.coerce.number().int().positive().default(12),
 });
 
 export const CreatePostBodySchema = PostSchema.pick({

--- a/src/lib/hono/schemas/community.schema.ts
+++ b/src/lib/hono/schemas/community.schema.ts
@@ -4,7 +4,7 @@ import UserSchema from "@zod/modelSchema/UserSchema";
 import { CursorPaginationSchema } from "./common.schema";
 import { PostCategory } from "@prisma/client";
 
-// API 응답용 스키마
+// API 응답용 스키마 (목록용)
 export const PostResponseSchema = PostSchema.extend({
   author: UserSchema.pick({
     id: true,
@@ -16,6 +16,21 @@ export const PostResponseSchema = PostSchema.extend({
 }).omit({
   userId: true,
   published: true,
+});
+
+// 게시글 상세 조회 응답 스키마
+export const PostDetailResponseSchema = PostResponseSchema.extend({
+  isAuthor: z.boolean(),
+});
+
+// 게시글 상태 조회
+export const PostStatusResponseSchema = PostSchema.pick({
+  viewCount: true,
+  likeCount: true,
+  commentCount: true,
+}).extend({
+  isLiked: z.boolean(),
+  isBookmarked: z.boolean(),
 });
 
 // 글 목록 조회 쿼리
@@ -53,6 +68,8 @@ export const PaginatedPostListResponseSchema = z.object({
 // 타입 추론
 export type GetPostsQuery = z.infer<typeof GetPostsQuerySchema>;
 export type PostResponse = z.infer<typeof PostResponseSchema>;
+export type PostDetailResponse = z.infer<typeof PostDetailResponseSchema>;
+export type PostStatusResponse = z.infer<typeof PostStatusResponseSchema>;
 export type CreatePost = z.infer<typeof CreatePostBodySchema>;
 export type CreatePostPayload = z.infer<typeof CreatePostPayloadSchema>;
 export type UpdatePost = z.infer<typeof UpdatePostSchema>;

--- a/src/lib/hono/services/community.service.ts
+++ b/src/lib/hono/services/community.service.ts
@@ -72,8 +72,9 @@ export async function getPaginatedPostListService(
 }
 
 export async function getPostByIdService(
-  id: string
-): Promise<ServiceResult<PostWithAuthor>> {
+  id: string,
+  userId?: string | null
+): Promise<ServiceResult<CommunitySchemas.PostDetailResponse>> {
   try {
     const post = await prisma.post.findUnique({
       where: { id },
@@ -83,7 +84,54 @@ export async function getPostByIdService(
     if (!post) {
       return serviceNotFound("게시글을 찾을 수 없습니다.");
     }
-    return serviceSuccess(post);
+
+    const isAuthor = post.userId === userId;
+    const result: CommunitySchemas.PostDetailResponse = {
+      ...post,
+      isAuthor,
+      createdAt: post.createdAt.toISOString(),
+      updatedAt: post.updatedAt?.toISOString() || null,
+    };
+    return serviceSuccess(result);
+  } catch (error) {
+    return serviceInternalError(error);
+  }
+}
+
+export async function getPostStatusByIdService(
+  postId: string,
+  userId?: string | null
+): Promise<ServiceResult<CommunitySchemas.PostStatusResponse>> {
+  try {
+    const [postCounts, like, bookmark] = await Promise.all([
+      prisma.post.findUnique({
+        where: { id: postId },
+        select: { viewCount: true, likeCount: true, commentCount: true },
+      }),
+
+      userId
+        ? prisma.postLike.findUnique({
+            where: { user_post_like_unique: { postId, userId } },
+          })
+        : null,
+      userId
+        ? prisma.postBookmark.findUnique({
+            where: { user_post_bookmark_unique: { postId, userId } },
+          })
+        : null,
+    ]);
+
+    if (!postCounts) {
+      return serviceNotFound("게시글 상태 정보를 찾을 수 없습니다.");
+    }
+
+    const result: CommunitySchemas.PostStatusResponse = {
+      ...postCounts,
+      isLiked: !!like,
+      isBookmarked: !!bookmark,
+    };
+
+    return serviceSuccess(result);
   } catch (error) {
     return serviceInternalError(error);
   }

--- a/src/lib/hono/services/community.service.ts
+++ b/src/lib/hono/services/community.service.ts
@@ -56,8 +56,14 @@ export async function getPaginatedPostListService(
       prisma.post.count({ where }),
     ]);
 
+    const transformedPosts = posts.map((post) => ({
+      //논의 필요
+      ...post,
+      createdAt: post.createdAt.toISOString(),
+      updatedAt: post.updatedAt?.toISOString() || null,
+    }));
     const paginatedResult = createCursorPaginationResult(
-      posts,
+      transformedPosts,
       totalCount,
       limit
     );


### PR DESCRIPTION
### 📌요구사항

- [x] 마이그레이션 게시글 목록 api 연동 

게시글 상세페이지 

- [x] 댓글,대댓글 작성 api 연동
- [x] 댓글 목록 api 연동 ( 커서 연결예정)
- [x] 북마크, 좋아요 api 연동


### 📌작업 진행 상황 (에러, 막혔던 부분, 그외 궁금한것 등등)

게시글 상세페이지 

댓글 목록 커서 기능 추가 필요
다음글/이전글 id 필요!

### 📌스크린샷 / 

https://github.com/user-attachments/assets/d52dd5f3-e892-4e89-9989-3e3fe3fc95f6

테스트결과 (선택)

### 📌이슈 번호
#70 #64