### PR TITLE
Feat: 게시글 상세조회 응답에 관련된 향수 정보 추가 및 컴포넌트 연결

### DIFF
--- a/src/components/commons/ckeditor5/EditorLoading.tsx
+++ b/src/components/commons/ckeditor5/EditorLoading.tsx
@@ -1,5 +1,5 @@
 export default function EditorPlaceholder() {
   return (
-    <div className="w-full min-h-[640px] bg-gray-300 animate-pulse rounded-[0.5rem]" />
+    <div className="w-full min-h-[440px] tablet:min-h-[640px] bg-gray-300 animate-pulse rounded-[0.5rem]" />
   );
 }

--- a/src/components/commons/ckeditor5/ckeditor5.css
+++ b/src/components/commons/ckeditor5/ckeditor5.css
@@ -13,7 +13,6 @@
 
 .ck-content {
   line-height: 1.6;
-  min-height: 600px;
   word-break: break-word;
 }
 
@@ -46,4 +45,16 @@
 .ck.ck-editor__editable > .ck-placeholder::before {
   color: #a8a8a8;
   font-size: 15px;
+}
+.editor-container_classic-editor .ck-content {
+  min-height: 600px;
+}
+
+@media (max-width: 767px) {
+  .editor-container_classic-editor .ck-content {
+    min-height: 400px;
+  }
+  .editor-container_classic-editor .editor-container__editor {
+    min-height: 440px;
+  }
 }

--- a/src/components/domains/post/form/element/SubTitleLabel.tsx
+++ b/src/components/domains/post/form/element/SubTitleLabel.tsx
@@ -11,7 +11,8 @@ export default function SubTitleLabel({
   isRequired = false,
   id,
 }: ISubTitleLabelProps) {
-  const subTitleStyle = "text-black-100 text-title-1 font-semibold ";
+  const subTitleStyle =
+    "text-black-100 text-title-1 font-semibold mt-2 tablet:mt-0";
 
   return htmlFor ? (
     <label className={subTitleStyle} htmlFor={htmlFor}>

--- a/src/components/domains/post/header/index.tsx
+++ b/src/components/domains/post/header/index.tsx
@@ -2,7 +2,7 @@ import CautionCard from "./CautionCard";
 
 export default function Header() {
   return (
-    <header className="w-full my-10">
+    <header className="w-full mt-6  tablet:my-10">
       <h1 className="mb-10 text-black-100 font-bold text-headline-2 tablet:text-headline-1 text-center">
         글 작성
       </h1>

--- a/src/components/domains/postDetail/PageClient.tsx
+++ b/src/components/domains/postDetail/PageClient.tsx
@@ -45,7 +45,7 @@ export default function PageClient({
         postId={postDetail.id}
         content={content}
         isAuthor={postDetail.isAuthor}
-        relatedPerfumes={[]}
+        relatedPerfumes={postDetail.perfumes}
       />
       <CommentSection
         postId={postDetail.id}

--- a/src/components/domains/postDetail/commentSection/index.tsx
+++ b/src/components/domains/postDetail/commentSection/index.tsx
@@ -63,7 +63,7 @@ export default function CommentSection({
 
   return (
     <section className="px-4">
-      <h2 className="text-title-2 tablet:text-headline-2 font-semibold text-black-100">
+      <h2 className="text-title-2 tablet:text-headline-3 font-semibold text-black-100">
         댓글 {totalCommentCount}
       </h2>
       <CommentForm

--- a/src/components/domains/postDetail/content/RelatedPerfume.tsx
+++ b/src/components/domains/postDetail/content/RelatedPerfume.tsx
@@ -1,16 +1,10 @@
 "use client";
 import PerfumeCard from "@/components/commons/card/perfumeCard";
-
-type TPerfume = {
-  perfume_id: number;
-  image_url: string;
-  brand_name: string;
-  brand_id: number;
-  perfume_name: string;
-};
+import { PostRelatedPerfumeResponse } from "@/lib/hono/schemas/community.schema";
+import Link from "next/link";
 
 interface IRelatedPerfumeProps {
-  perfumes: TPerfume[] | [];
+  perfumes: PostRelatedPerfumeResponse[];
 }
 
 export default function RelatedPerfume({ perfumes }: IRelatedPerfumeProps) {
@@ -19,14 +13,23 @@ export default function RelatedPerfume({ perfumes }: IRelatedPerfumeProps) {
       <h2 className="text-title-2 tablet:text-headline-3 font-semibold text-black-100">
         관련된 향수
       </h2>
-      <div className="flex items-center gap-5 mt-4">
-        {perfumes.map((item) => (
-          <PerfumeCard
-            key={item.perfume_id}
-            perfumeImage={item.image_url}
-            perfumeName={item.perfume_name}
-            brandName={item.brand_name}
-          />
+      <div className="grid tablet:grid-cols-5 grid-cols-3 tablet:gap-x-6 gap-x-4  mobile:gap-y-5 gap-y-4 mt-5">
+        {perfumes.map((item: PostRelatedPerfumeResponse) => (
+          <Link key={item.id} href={`/perfumes/${item.id}`}>
+            <PerfumeCard
+              className="tablet:block hidden"
+              perfumeImage={item.perfumeImage?.imageUrl ?? null}
+              perfumeName={item.nameKo ?? item.nameEn}
+              brandName={item.brand.nameKo ?? item.brand.nameEn}
+            />
+            <PerfumeCard
+              className="tablet:hidden block"
+              cardType="smallSize"
+              perfumeImage={item.perfumeImage?.imageUrl ?? null}
+              perfumeName={item.nameKo ?? item.nameEn}
+              brandName={item.brand.nameKo ?? item.brand.nameEn}
+            />
+          </Link>
         ))}
       </div>
     </section>

--- a/src/components/domains/postDetail/content/index.tsx
+++ b/src/components/domains/postDetail/content/index.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { PostRelatedPerfumeResponse } from "@/lib/hono/schemas/community.schema";
 import PostActions from "../header/PostActions";
 import RelatedPerfume from "./RelatedPerfume";
 import PostNavigation from "./postNavigation";
@@ -7,7 +8,7 @@ import { useSanitizedHtml } from "@/lib/hooks/useSanitizedHtml";
 interface IPostContent {
   content: string;
   isAuthor?: boolean;
-  relatedPerfumes?: [];
+  relatedPerfumes: PostRelatedPerfumeResponse[] | [];
   postId: string;
 }
 

--- a/src/components/domains/postDetail/content/index.tsx
+++ b/src/components/domains/postDetail/content/index.tsx
@@ -2,7 +2,6 @@
 import { PostRelatedPerfumeResponse } from "@/lib/hono/schemas/community.schema";
 import PostActions from "../header/PostActions";
 import RelatedPerfume from "./RelatedPerfume";
-import PostNavigation from "./postNavigation";
 import { useSanitizedHtml } from "@/lib/hooks/useSanitizedHtml";
 
 interface IPostContent {
@@ -26,7 +25,7 @@ export default function PostContent({
     <section>
       <div className="px-4">
         <div
-          className="ck-content text-body-2 font-medium text-black-100 leading-6 mb-10"
+          className="ck-content text-body-1 font-medium text-black-100 leading-6 mb-40"
           dangerouslySetInnerHTML={{ __html: sanitizedContent }}
         />
 
@@ -37,9 +36,9 @@ export default function PostContent({
       {hasRelatedPerfumes && (
         <div className="divider-horizontal-thick block tablet:hidden" />
       )}
-      <div className="px-4">
+      <div className="px-4 tablet:mb-[60px]">
         {hasRelatedPerfumes && <RelatedPerfume perfumes={relatedPerfumes} />}
-        <PostNavigation />
+        {/* <PostNavigation /> */}
       </div>
       <div className="divider-horizontal-thick block tablet:hidden mb-10" />
     </section>

--- a/src/lib/hono/routes/v1/community.handler.ts
+++ b/src/lib/hono/routes/v1/community.handler.ts
@@ -73,7 +73,7 @@ const getPostRoute = createRoute({
   },
   responses: createStandardApiResponses(
     {
-      schema: CommunitySchemas.PostResponseSchema,
+      schema: CommunitySchemas.PostDetailResponseSchema,
       description: "게시글",
     },
     ["404"]

--- a/src/lib/hono/schemas/community.schema.ts
+++ b/src/lib/hono/schemas/community.schema.ts
@@ -99,3 +99,4 @@ export type PostIdParam = z.infer<typeof PostIdParamSchema>;
 export type PaginatedPostListResponse = z.infer<
   typeof PaginatedPostListResponseSchema
 >;
+export type PostRelatedPerfumeResponse = z.infer<typeof PerfumeForPostSchema>;

--- a/src/lib/hono/schemas/community.schema.ts
+++ b/src/lib/hono/schemas/community.schema.ts
@@ -18,9 +18,30 @@ export const PostResponseSchema = PostSchema.extend({
   published: true,
 });
 
+// 게시글 상세 조회용 Brand 이름 스키마
+const BrandForPerfumeSchema = z.object({
+  nameEn: z.string(),
+  nameKo: z.string().nullable(),
+});
+
+// 게시글 상세 조회용 Perfume 이미지 스키마
+const PerfumeImageForPerfumeSchema = z.object({
+  imageUrl: z.string(),
+});
+
+// 게시글 상세에 포함될 Perfume 스키마
+const PerfumeForPostSchema = z.object({
+  id: z.string().uuid(),
+  nameEn: z.string(),
+  nameKo: z.string().nullable(),
+  brand: BrandForPerfumeSchema,
+  perfumeImage: PerfumeImageForPerfumeSchema.nullable(),
+});
+
 // 게시글 상세 조회 응답 스키마
 export const PostDetailResponseSchema = PostResponseSchema.extend({
   isAuthor: z.boolean(),
+  perfumes: z.array(PerfumeForPostSchema),
 });
 
 // 게시글 상태 조회

--- a/src/lib/hono/services/community.service.ts
+++ b/src/lib/hono/services/community.service.ts
@@ -23,6 +23,30 @@ const postWithAuthorArgs = { include: postIncludeArgs };
 
 export type PostWithAuthor = Prisma.PostGetPayload<typeof postWithAuthorArgs>;
 
+const postDetailArgs = {
+  include: {
+    ...postIncludeArgs,
+    perfumeMappings: {
+      select: {
+        perfume: {
+          select: {
+            id: true,
+            nameEn: true,
+            nameKo: true,
+            brand: {
+              select: {
+                nameEn: true,
+                nameKo: true,
+              },
+            },
+            perfumeImage: { select: { imageUrl: true } },
+          },
+        },
+      },
+    },
+  },
+};
+
 // --- 서비스 함수들 ---
 export async function getPaginatedPostListService(
   params: CommunitySchemas.GetPostsQuery
@@ -91,18 +115,19 @@ export async function getPostByIdService(
       });
       return tx.post.findUnique({
         where: { id },
-        ...postWithAuthorArgs,
+        ...postDetailArgs,
       });
     });
 
     if (!post) {
       return serviceNotFound("게시글을 찾을 수 없습니다.");
     }
-
+    const { perfumeMappings, ...restOfPost } = post;
     const isAuthor = post.userId === userId;
     const result: CommunitySchemas.PostDetailResponse = {
-      ...post,
+      ...restOfPost,
       isAuthor,
+      perfumes: perfumeMappings.map((mapping) => mapping.perfume),
       createdAt: post.createdAt.toISOString(),
       updatedAt: post.updatedAt?.toISOString() || null,
     };


### PR DESCRIPTION
### 📌요구사항

- [x]  게시글 상세조회 응답에 관련된 향수 정보 추가 
- [x] 관련된 향수 정보 컴포넌트 연결
- [x] 이전글 다음글 버튼 제거

### 📌작업 진행 상황 (에러, 막혔던 부분, 그외 궁금한것 등등)

### 📌스크린샷 / 테스트결과 (선택)
<img width="1077" height="1173" alt="image" src="https://github.com/user-attachments/assets/fde0dcb6-d380-4c1b-8d3f-62019cbf94b2" />

### 📌이슈 번호
#70 