### PR TITLE
Feat: 텍스트 에디터에 프리뷰 기능 추가

### DIFF
--- a/src/components/commons/ckeditor5/CkEditor5.tsx
+++ b/src/components/commons/ckeditor5/CkEditor5.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useMemo } from "react";
+import { useState, useEffect, useRef, useMemo, MutableRefObject } from "react";
 import { CKEditor } from "@ckeditor/ckeditor5-react";
 import {
   ClassicEditor,
@@ -31,26 +31,41 @@ import {
 } from "ckeditor5";
 
 import translations from "ckeditor5/translations/ko.js";
-import supabaseUploadPlugin from "@/lib/ckeditor/supabaseUploadPlugin";
+import makeLocalPreviewUploadPlugin, {
+  BlobRegistry,
+} from "@/lib/ckeditor/localPreviewUploadPlugin";
 
 const LICENSE_KEY = "GPL";
 
 export default function CkEditor5({
   content,
   onChange,
+  blobRegistryRef,
 }: {
   content?: string;
   onChange: (newContent: string) => void;
+  blobRegistryRef: MutableRefObject<BlobRegistry>;
 }) {
   const editorContainerRef = useRef(null);
   const editorRef = useRef(null);
   const [isLayoutReady, setIsLayoutReady] = useState(false);
 
+  const localPreviewPlugin = useMemo(
+    () => makeLocalPreviewUploadPlugin(blobRegistryRef.current),
+    [blobRegistryRef]
+  );
+
   useEffect(() => {
     setIsLayoutReady(true);
 
-    return () => setIsLayoutReady(false);
-  }, []);
+    return () => {
+      for (const url of blobRegistryRef.current.keys()) {
+        URL.revokeObjectURL(url);
+      }
+      blobRegistryRef.current.clear();
+      setIsLayoutReady(false);
+    };
+  }, [blobRegistryRef]);
 
   const { editorConfig } = useMemo(() => {
     if (!isLayoutReady) {
@@ -110,7 +125,7 @@ export default function CkEditor5({
           Underline,
         ],
 
-        extraPlugins: [supabaseUploadPlugin],
+        extraPlugins: [localPreviewPlugin],
         balloonToolbar: ["bold", "italic", "|", "link"],
         heading: {
           options: [

--- a/src/components/domains/post/form/PostEditor.tsx
+++ b/src/components/domains/post/form/PostEditor.tsx
@@ -2,12 +2,18 @@ import dynamic from "next/dynamic";
 import SubTitleLabel from "./element/SubTitleLabel";
 import EditorLoading from "@/components/commons/ckeditor5/EditorLoading";
 import { Controller, useFormContext } from "react-hook-form";
+import { BlobRegistry } from "@/lib/ckeditor/localPreviewUploadPlugin";
+import { MutableRefObject } from "react";
 const CkEditor5 = dynamic(
   () => import("@/components/commons/ckeditor5/CkEditor5"),
   { ssr: false, loading: () => <EditorLoading /> }
 );
 
-export default function PostEditor() {
+export default function PostEditor({
+  blobRegistryRef,
+}: {
+  blobRegistryRef: MutableRefObject<BlobRegistry>;
+}) {
   const { control } = useFormContext();
 
   return (
@@ -17,7 +23,11 @@ export default function PostEditor() {
         name="content"
         control={control}
         render={({ field }) => (
-          <CkEditor5 content={field.value} onChange={field.onChange} />
+          <CkEditor5
+            content={field.value}
+            onChange={field.onChange}
+            blobRegistryRef={blobRegistryRef}
+          />
         )}
       />
     </>

--- a/src/components/domains/post/form/index.tsx
+++ b/src/components/domains/post/form/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import PostEditor from "./PostEditor";
 import PostFormActions from "./PostFormActions";
@@ -17,6 +17,8 @@ import {
 import getPlainText from "@/lib/utils/getPlainText";
 import { PostCategory as TPostCategory } from "@prisma/client";
 import PostRelatedPerfume from "./postRelatedPerfume/PostRelatedPerfume";
+import { BlobRegistry } from "@/lib/ckeditor/localPreviewUploadPlugin";
+import { finalizeWithBlobRegistry } from "@/lib/ckeditor/finalizeWithBlobRegistry";
 
 interface IPostFormProps {
   type: "create" | "edit";
@@ -26,6 +28,7 @@ interface IPostFormProps {
 export default function PostForm({ type, initialData }: IPostFormProps) {
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
+  const blobRegistryRef = useRef<BlobRegistry>(new Map());
 
   const method = useForm<CreatePost>({
     resolver: zodResolver(CreatePostBodySchema),
@@ -42,16 +45,23 @@ export default function PostForm({ type, initialData }: IPostFormProps) {
   const {
     handleSubmit,
     formState: { isValid, isDirty },
+    setValue,
   } = method;
 
   const onSubmit = async (data: CreatePost) => {
     setIsLoading(true);
 
     try {
-      const thumbnailUrl = extractFirstImageSrc(data.content);
-      const contentText = getPlainText(data.content);
+      const finalizedContent = await finalizeWithBlobRegistry(
+        data.content,
+        blobRegistryRef.current
+      );
+      setValue("content", finalizedContent, { shouldDirty: true });
+      const thumbnailUrl = extractFirstImageSrc(finalizedContent);
+      const contentText = getPlainText(finalizedContent);
       const postData: CreatePost = {
         ...data,
+        content: finalizedContent,
         thumbnailUrl,
         contentText,
       };
@@ -81,7 +91,7 @@ export default function PostForm({ type, initialData }: IPostFormProps) {
         <div className="w-full grid grid-cols-1 tablet:grid-cols-[85px_1fr] tablet:gap-x-[30px] pc:gap-x-[200px] gap-y-2 tablet:gap-y-14">
           <PostCategory />
           <PostTitle />
-          <PostEditor />
+          <PostEditor blobRegistryRef={blobRegistryRef} />
           <PostRelatedPerfume />
         </div>
         <PostFormActions disabled={disabled} />

--- a/src/lib/ckeditor/finalizeWithBlobRegistry.ts
+++ b/src/lib/ckeditor/finalizeWithBlobRegistry.ts
@@ -1,0 +1,36 @@
+import { BlobRegistry } from "@/lib/ckeditor/localPreviewUploadPlugin";
+import {
+  POST_IMAGE_MAX_SIZE,
+  getPostImageUrl,
+} from "@/lib/queries/community/postsImageUrl";
+
+export async function finalizeWithBlobRegistry(
+  html: string,
+  registry: BlobRegistry
+) {
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  const imgs = Array.from(doc.querySelectorAll("img[src^='blob:']"));
+
+  for (const img of imgs) {
+    const src = img.getAttribute("src")!;
+    const file = registry.get(src);
+    if (!file) {
+      continue;
+    }
+
+    if (file.size > POST_IMAGE_MAX_SIZE) {
+      throw new Error("5MB 이하 이미지 파일만 업로드할 수 있습니다.");
+    }
+
+    const url = await getPostImageUrl(file);
+    if (!url) {
+      throw new Error("이미지 업로드에 실패했습니다.");
+    }
+
+    img.setAttribute("src", url);
+    URL.revokeObjectURL(src);
+    registry.delete(src);
+  }
+
+  return doc.body.innerHTML;
+}

--- a/src/lib/ckeditor/localPreviewUploadPlugin.ts
+++ b/src/lib/ckeditor/localPreviewUploadPlugin.ts
@@ -1,0 +1,36 @@
+import { Editor, FileLoader } from "ckeditor5";
+import { POST_IMAGE_MAX_SIZE } from "../queries/community/postsImageUrl";
+
+export type BlobRegistry = Map<string, File>;
+
+class LocalPreviewAdapter {
+  private loader: FileLoader;
+  private registry: BlobRegistry;
+
+  constructor(loader: FileLoader, registry: BlobRegistry) {
+    this.loader = loader;
+    this.registry = registry;
+  }
+
+  async upload() {
+    const file = await this.loader.file;
+    if (!file) throw new Error("파일이 존재하지 않습니다.");
+    if (file.size > POST_IMAGE_MAX_SIZE) {
+      return Promise.reject("5MB 이하 이미지 파일만 업로드할 수 있습니다.");
+    }
+
+    const objectURL = URL.createObjectURL(file);
+    this.registry.set(objectURL, file);
+    return { default: objectURL };
+  }
+
+  abort() {}
+}
+
+export default function makeLocalPreviewUploadPlugin(registry: BlobRegistry) {
+  return function localPreviewUploadPlugin(editor: Editor) {
+    editor.plugins.get("FileRepository").createUploadAdapter = (
+      loader: FileLoader
+    ) => new LocalPreviewAdapter(loader, registry);
+  };
+}


### PR DESCRIPTION
### 📌요구사항

- [x] 텍스트 에디터에 프리뷰 기능 추가

### 📌작업 진행 상황 (에러, 막혔던 부분, 그외 궁금한것 등등)

- 텍스트 에디터에 이미지 첨부 시 수파베이스에 이미지가 저장 되지 않고 프리뷰만 보이는 것을 확인했습니다.
- 게시글을 post 하면 이전과 같이 수파베이스에 이미지가 저장 됩니다.
- 이미지 사이즈를 조정한 상황에서도 정상적으로 작동하는 걸 확인했습니다.

### 📌스크린샷 / 테스트결과 (선택)

### 📌이슈 번호
close #90 
