### PR TITLE
Feat: 댓글 삭제 api 구현 및 연동 / 상세페이지 데이터 fetching 로직을 TanStack Query로 전환

### DIFF
--- a/src/app/community/post/[id]/page.tsx
+++ b/src/app/community/post/[id]/page.tsx
@@ -5,6 +5,8 @@ import {
 } from "@/components/domains/postDetail/postDetail.helpers";
 import PageClient from "@/components/domains/postDetail/PageClient";
 import { getCommentsByPostId } from "@/components/domains/postDetail/commentSection/comment.helper";
+import getQueryClient from "@/lib/hono/utils/getQueryClient";
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 
 export default async function Page({
   params,
@@ -18,28 +20,29 @@ export default async function Page({
     Cookie: cookieStore.toString(),
   };
 
-  try {
-    const [postResult, postStatusResult, commentsResult] = await Promise.all([
-      getPostDetailById(id, requestHeaders),
-      getPostDetailStatusById(id, requestHeaders),
-      getCommentsByPostId(id),
-    ]);
+  const queryClient = getQueryClient();
 
-    return (
-      <>
-        <PageClient
-          postDetail={postResult.data}
-          postStatus={postStatusResult.data}
-          initialCommentsResult={commentsResult.data}
-        />
-      </>
-    );
-  } catch (error) {
-    console.error("Error fetching post details:", error);
-    return (
-      <div className="flex flex-col items-center justify-center h-screen">
-        게시글을 불러오는 데 실패했거나, 존재하지 않는 게시글입니다.
-      </div>
-    );
-  }
+  await Promise.all([
+    queryClient.prefetchQuery({
+      queryKey: ["post", id],
+      queryFn: () => getPostDetailById(id, requestHeaders),
+    }),
+    queryClient.prefetchQuery({
+      queryKey: ["post", id, "status"],
+      queryFn: () => getPostDetailStatusById(id, requestHeaders),
+    }),
+    queryClient.prefetchInfiniteQuery({
+      queryKey: ["post", id, "comments"],
+      queryFn: () => getCommentsByPostId(id),
+      initialPageParam: null,
+    }),
+  ]);
+
+  const dehydratedState = dehydrate(queryClient);
+
+  return (
+    <HydrationBoundary state={dehydratedState}>
+      <PageClient postId={id} />
+    </HydrationBoundary>
+  );
 }

--- a/src/components/commons/author/PostTime.tsx
+++ b/src/components/commons/author/PostTime.tsx
@@ -34,7 +34,7 @@ export default function PostTime({ time, type, size }: PostTimeProps) {
         size === SIZE_STATUSES.DEFAULT
           ? "text-label-4 tablet:text-label-2"
           : "text-body-1"
-      } font-medium text-black-300`}
+      } font-medium ${type === "comment" ? "text-gray-100" : "text-black-300"}`}
     >
       {formattedTime}
     </span>

--- a/src/components/domains/postDetail/PageClient.tsx
+++ b/src/components/domains/postDetail/PageClient.tsx
@@ -24,6 +24,7 @@ export default function PageClient({ postId }: { postId: string }) {
   if (!postDetail || !postStatus) {
     return <div>Loading...</div>;
   }
+
   const { content, ...postDetailHeader } = postDetail;
 
   return (
@@ -37,6 +38,7 @@ export default function PageClient({ postId }: { postId: string }) {
       />
       <CommentSection
         postId={postId}
+        postAuthorId={postDetail.author.id}
         totalCommentCount={postStatus.commentCount}
       />
     </article>

--- a/src/components/domains/postDetail/PageClient.tsx
+++ b/src/components/domains/postDetail/PageClient.tsx
@@ -1,57 +1,43 @@
 "use client";
 
-import { SearchResponse } from "@/lib/hooks/useInfinityScroll";
 import CommentSection from "./commentSection";
 import PostContent from "./content";
 import PostDetailHeader from "./header";
-import { CommentResponse } from "@/lib/hono/schemas/comment.schema";
+import { useQuery } from "@tanstack/react-query";
 import {
-  PostDetailResponse,
-  PostStatusResponse,
-} from "@/lib/hono/schemas/community.schema";
-import { useState } from "react";
+  getPostDetailById,
+  getPostDetailStatusById,
+} from "./postDetail.helpers";
 
-interface IPostDetailPageClientProps {
-  postDetail: PostDetailResponse;
-  postStatus: PostStatusResponse;
-  initialCommentsResult: SearchResponse<CommentResponse>;
-}
+export default function PageClient({ postId }: { postId: string }) {
+  const { data: postDetail } = useQuery({
+    queryKey: ["post", postId],
+    queryFn: () => getPostDetailById(postId),
+    staleTime: 1000 * 60 * 5,
+  });
 
-export default function PageClient({
-  postDetail,
-  postStatus,
-  initialCommentsResult,
-}: IPostDetailPageClientProps) {
+  const { data: postStatus } = useQuery({
+    queryKey: ["post", postId, "status"],
+    queryFn: () => getPostDetailStatusById(postId),
+  });
+
+  if (!postDetail || !postStatus) {
+    return <div>Loading...</div>;
+  }
   const { content, ...postDetailHeader } = postDetail;
-
-  const [totalCommentCount, setTotalCommentCount] = useState(
-    postStatus.commentCount || 0
-  );
-
-  const changeCommentCount = (change: 1 | -1) => {
-    setTotalCommentCount((prev) => {
-      const updated = prev + change;
-      return updated < 0 ? 0 : updated;
-    });
-  };
 
   return (
     <article>
-      <PostDetailHeader
-        postStatus={{ ...postStatus, commentCount: totalCommentCount }}
-        {...postDetailHeader}
-      />
+      <PostDetailHeader postStatus={postStatus} {...postDetailHeader} />
       <PostContent
-        postId={postDetail.id}
+        postId={postId}
         content={content}
         isAuthor={postDetail.isAuthor}
         relatedPerfumes={postDetail.perfumes}
       />
       <CommentSection
-        postId={postDetail.id}
-        initialCommentsResult={initialCommentsResult}
-        totalCommentCount={totalCommentCount}
-        changeCommentCount={changeCommentCount}
+        postId={postId}
+        totalCommentCount={postStatus.commentCount}
       />
     </article>
   );

--- a/src/components/domains/postDetail/commentSection/comment.helper.ts
+++ b/src/components/domains/postDetail/commentSection/comment.helper.ts
@@ -1,11 +1,17 @@
 import {
   CommentResponse,
   CreateCommentBody,
+  DeleteCommentResponse,
 } from "@/lib/hono/schemas/comment.schema";
 import { ApiSuccessResponse } from "@/lib/hono/utils/response.constants";
 import { SearchResponse } from "@/lib/hooks/useInfinityScroll";
+import { createHttpClient } from "@/lib/utils/core-request";
 
 const API_BASE_URL = "http://localhost:3000/api/v1";
+
+const apiClient = createHttpClient({
+  baseUrl: process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL,
+});
 
 export async function createNewComment(
   postId: string,
@@ -73,10 +79,17 @@ export async function getCommentsByPostId(
       );
     }
     const result = await response.json();
-
     return result;
   } catch (error) {
     console.error("Error fetching comments:", error);
     throw error;
   }
+}
+
+export async function deleteCommentById(
+  commentId: string
+): Promise<DeleteCommentResponse | null> {
+  return await apiClient.delete<DeleteCommentResponse>(
+    `/comments/${commentId}`
+  );
 }

--- a/src/components/domains/postDetail/commentSection/comment/CommentAuthInfo.tsx
+++ b/src/components/domains/postDetail/commentSection/comment/CommentAuthInfo.tsx
@@ -1,34 +1,20 @@
-import AuthorInfo from "@/components/commons/author/AuthorInfo";
-import {
-  ICommentAuthInfoProps,
-  ICommentAuthProfileProps,
-} from "./postComment.types";
+import { ICommentAuthInfoProps } from "./postComment.types";
 import AuthorProfile from "@/components/commons/author/AuthorProfile";
 
 export function CommentAuthInfo({
   author,
-  createdAt,
   profileImage,
+  size,
+  isPostAuthor,
 }: ICommentAuthInfoProps) {
   return (
-    <>
-      <AuthorInfo
-        info={{
-          type: "comment",
-        }}
-        author={author}
-        createdAt={createdAt}
-        profileImage={profileImage}
-        isAuthor={false}
-        // size="large"
-      />
-    </>
+    <div className="text-black-200 flex items-center justify-center gap-2">
+      <AuthorProfile name={author} profileImage={profileImage} size={size} />
+      {isPostAuthor && (
+        <div className="text-label-5 text-primary-100 border rounded-full px-1 border-primary-100 ">
+          작성자
+        </div>
+      )}
+    </div>
   );
-}
-
-export function CommentUserProfile({
-  author,
-  profileImage,
-}: ICommentAuthProfileProps) {
-  return <AuthorProfile name={author} profileImage={profileImage} size={36} />;
 }

--- a/src/components/domains/postDetail/commentSection/comment/CommentForm.tsx
+++ b/src/components/domains/postDetail/commentSection/comment/CommentForm.tsx
@@ -5,7 +5,7 @@ import { ButtonOutlinedPrimaryLFit } from "@/components/commons/button/ButtonOut
 import Comment from "@/components/commons/comment";
 import { useState } from "react";
 import { ICommentFormProps } from "./postComment.types";
-import { createNewComment } from "../comment.helper";
+import useCommentMutation from "../useCommentMutation";
 
 export default function CommentForm({
   type,
@@ -21,34 +21,29 @@ export default function CommentForm({
     setInputValue(inputValue);
   };
 
+  const { uploadMutation } = useCommentMutation(postId);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!inputValue.trim()) return;
     try {
-      let response;
       switch (type) {
         case "create":
-          response = await createNewComment(postId, {
-            content: inputValue,
-          });
-          if (response.success) {
-            setInputValue("");
-            onSuccess?.({ type: "ADD_NEW_COMMENT", payload: response.data });
-          }
-
+          uploadMutation.mutate(
+            { content: inputValue },
+            { onSuccess: () => setInputValue("") }
+          );
           break;
         case "reply":
-          response = await createNewComment(postId, {
-            content: inputValue,
-            parentId: commentId,
-          });
-          if (response.success) {
-            setInputValue("");
-            onSuccess?.({
-              type: "ADD_NEW_REPLY",
-              payload: response.data,
-            });
-          }
+          uploadMutation.mutate(
+            { content: inputValue, parentId: commentId },
+            {
+              onSuccess: () => {
+                setInputValue("");
+                onSuccess?.();
+              },
+            }
+          );
 
           break;
         case "edit":
@@ -56,8 +51,6 @@ export default function CommentForm({
           // onSuccess?.();
           break;
       }
-
-      setInputValue("");
     } catch (error) {
       console.error("댓글 작성 실패:", error);
       alert("오류가 발생했습니다. 다시 시도해 주세요.");

--- a/src/components/domains/postDetail/commentSection/comment/CommentForm.tsx
+++ b/src/components/domains/postDetail/commentSection/comment/CommentForm.tsx
@@ -22,6 +22,7 @@ export default function CommentForm({
   };
 
   const { uploadMutation } = useCommentMutation(postId);
+  const { isPending: isCreating } = uploadMutation;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -68,8 +69,7 @@ export default function CommentForm({
       {type === "create" && (
         <ButtonFilledPrimaryLFit
           colorNum="200"
-          onClick={() => handleSubmit}
-          disabled={!inputValue.trim()}
+          disabled={!inputValue.trim() || isCreating}
           type="submit"
         >
           댓글 작성
@@ -77,19 +77,14 @@ export default function CommentForm({
       )}
       {type === "reply" && (
         <ButtonOutlinedPrimaryLFit
-          onClick={() => handleSubmit}
-          disabled={!inputValue.trim()}
+          disabled={!inputValue.trim() || isCreating}
           type="submit"
         >
           답글 작성
         </ButtonOutlinedPrimaryLFit>
       )}
       {type === "edit" && (
-        <ButtonOutlinedPrimaryLFit
-          onClick={() => handleSubmit}
-          disabled={!inputValue.trim()}
-          type="submit"
-        >
+        <ButtonOutlinedPrimaryLFit disabled={!inputValue.trim()} type="submit">
           댓글 수정
         </ButtonOutlinedPrimaryLFit>
       )}

--- a/src/components/domains/postDetail/commentSection/comment/CommentIList.tsx
+++ b/src/components/domains/postDetail/commentSection/comment/CommentIList.tsx
@@ -12,6 +12,7 @@ export default function CommentList({
   onLoadMore,
   hasNextCursor,
   isLoadingComments,
+  postAuthorId,
 }: ICommentIListProps) {
   const [editingCommentId, setEditingCommentId] = useState<string | null>(null);
   const [replyingCommentId, setReplyingCommentId] = useState<string | null>(
@@ -31,6 +32,7 @@ export default function CommentList({
           commentList.map((comment: CommentResponse) => (
             <CommentListItem
               key={comment.id}
+              postAuthorId={postAuthorId}
               commentActionState={commentActionState}
               comment={comment}
             />

--- a/src/components/domains/postDetail/commentSection/comment/CommentIList.tsx
+++ b/src/components/domains/postDetail/commentSection/comment/CommentIList.tsx
@@ -5,12 +5,12 @@ import CommentListItem from "./CommentListItem";
 import { ICommentIListProps, TCommentActionState } from "./postComment.types";
 import { useState } from "react";
 import ArrowIcon from "@/components/commons/icons/arrowIcon";
+import { CommentResponse } from "@/lib/hono/schemas/comment.schema";
 
 export default function CommentList({
   commentList,
   onLoadMore,
-  onAction,
-  nextCursor,
+  hasNextCursor,
   isLoadingComments,
 }: ICommentIListProps) {
   const [editingCommentId, setEditingCommentId] = useState<string | null>(null);
@@ -28,18 +28,17 @@ export default function CommentList({
     <section className="flex flex-col items-center">
       <ul className="flex flex-col w-full">
         {commentList.length > 0 &&
-          commentList.map((comment) => (
+          commentList.map((comment: CommentResponse) => (
             <CommentListItem
               key={comment.id}
               commentActionState={commentActionState}
               comment={comment}
-              onAction={onAction}
             />
           ))}
       </ul>
-      {nextCursor && (
+      {hasNextCursor && (
         <ButtonFilledGrayLFixed
-          disabled={isLoadingComments || !nextCursor}
+          disabled={isLoadingComments || !hasNextCursor}
           onClick={onLoadMore}
           iconTrailing={
             <ArrowIcon color="gray-100" size="16" direction="down" />

--- a/src/components/domains/postDetail/commentSection/comment/CommentListItem.tsx
+++ b/src/components/domains/postDetail/commentSection/comment/CommentListItem.tsx
@@ -8,17 +8,16 @@ import {
   CommentResponse,
 } from "@/lib/hono/schemas/comment.schema";
 import { useUserStore } from "@/lib/stores/useUserStore";
-import { CommentAction, DELETE_COMMENT } from "../comment.reducer";
+import useCommentMutation from "../useCommentMutation";
 
 export default function CommentListItem({
   commentActionState,
   comment,
-  onAction,
+
   isReplyType = false,
 }: {
   commentActionState: TCommentActionState;
   comment: CommentResponse | CommentReplyResponse;
-  onAction: (action: CommentAction) => void;
   isReplyType?: boolean;
 }) {
   const {
@@ -34,6 +33,9 @@ export default function CommentListItem({
   const isReplying = replyingCommentId === id;
   const isAnyCommentBeingEdited = editingCommentId !== null;
   const isAnyCommentBeingReplied = replyingCommentId !== null;
+
+  const { deleteMutation } = useCommentMutation(postId);
+
   const userActions: ActionItem[] = [
     {
       type: "reply",
@@ -58,8 +60,7 @@ export default function CommentListItem({
       type: "delete",
       onClick: () => {
         if (window.confirm("댓글을 삭제하시겠습니까?")) {
-          //삭제 api 구현 후 연동 필요
-          onAction({ type: DELETE_COMMENT, payload: { id, parentId } }); //삭제처리 답글이 있는 경우 고려 필요
+          deleteMutation.mutate(id);
         }
       },
       disabled: isAnyCommentBeingReplied || isAnyCommentBeingEdited,
@@ -88,13 +89,11 @@ export default function CommentListItem({
     }
   }
 
-  const onEditSuccess = (action: CommentAction) => {
-    onAction(action);
+  const onEditSuccess = () => {
     setEditingCommentId(null);
   };
 
-  const onReplySuccess = (action: CommentAction) => {
-    onAction(action);
+  const onReplySuccess = () => {
     setReplyingCommentId(null);
   };
 
@@ -141,7 +140,7 @@ export default function CommentListItem({
               commentActionState={commentActionState}
               comment={reply}
               isReplyType
-              onAction={onAction}
+              // onAction={onAction}
             />
           </ul>
         ))}

--- a/src/components/domains/postDetail/commentSection/comment/CommentListItem.tsx
+++ b/src/components/domains/postDetail/commentSection/comment/CommentListItem.tsx
@@ -38,9 +38,6 @@ export default function CommentListItem({
   const isAnyCommentBeingEdited = editingCommentId !== null;
   const isAnyCommentBeingReplied = replyingCommentId !== null;
 
-  console.log("authorId:", author.id, "postAuthorId:", postAuthorId);
-  console.log("isPostAuthor", isPostAuthor);
-
   const { deleteMutation } = useCommentMutation(postId);
 
   const userActions: ActionItem[] = [

--- a/src/components/domains/postDetail/commentSection/comment/CommentListItem.tsx
+++ b/src/components/domains/postDetail/commentSection/comment/CommentListItem.tsx
@@ -39,7 +39,7 @@ export default function CommentListItem({
   const isAnyCommentBeingReplied = replyingCommentId !== null;
 
   const { deleteMutation } = useCommentMutation(postId);
-
+  const { isPending: isDeleting } = deleteMutation;
   const userActions: ActionItem[] = [
     {
       type: "reply",
@@ -67,7 +67,8 @@ export default function CommentListItem({
           deleteMutation.mutate(id);
         }
       },
-      disabled: isAnyCommentBeingReplied || isAnyCommentBeingEdited,
+      disabled:
+        isAnyCommentBeingReplied || isAnyCommentBeingEdited || isDeleting,
     },
   ];
 

--- a/src/components/domains/postDetail/commentSection/comment/CommentListItem.tsx
+++ b/src/components/domains/postDetail/commentSection/comment/CommentListItem.tsx
@@ -1,5 +1,5 @@
 import { ActionItem, Actions } from "@/components/commons/actions";
-import { CommentAuthInfo, CommentUserProfile } from "./CommentAuthInfo";
+import { CommentAuthInfo } from "./CommentAuthInfo";
 import { TCommentActionState } from "./postComment.types";
 import CommentForm from "./CommentForm";
 import ReplyIcon from "./ReplyIcon";
@@ -9,15 +9,17 @@ import {
 } from "@/lib/hono/schemas/comment.schema";
 import { useUserStore } from "@/lib/stores/useUserStore";
 import useCommentMutation from "../useCommentMutation";
+import PostTime from "@/components/commons/author/PostTime";
 
 export default function CommentListItem({
   commentActionState,
   comment,
-
+  postAuthorId,
   isReplyType = false,
 }: {
   commentActionState: TCommentActionState;
   comment: CommentResponse | CommentReplyResponse;
+  postAuthorId: string;
   isReplyType?: boolean;
 }) {
   const {
@@ -27,12 +29,17 @@ export default function CommentListItem({
     setReplyingCommentId,
   } = commentActionState;
   const { user } = useUserStore();
-  const { id, author, createdAt, content, postId, parentId } = comment;
+  const { id, author, createdAt, content, postId, parentId, published } =
+    comment;
   const isAuthor = author.id === user?.id;
+  const isPostAuthor = author.id === postAuthorId;
   const isEditing = editingCommentId === id;
   const isReplying = replyingCommentId === id;
   const isAnyCommentBeingEdited = editingCommentId !== null;
   const isAnyCommentBeingReplied = replyingCommentId !== null;
+
+  console.log("authorId:", author.id, "postAuthorId:", postAuthorId);
+  console.log("isPostAuthor", isPostAuthor);
 
   const { deleteMutation } = useCommentMutation(postId);
 
@@ -100,19 +107,21 @@ export default function CommentListItem({
   return (
     <>
       <li>
-        <div className={`py-5 ${isReplyType && "flex gap-5"}`}>
+        <div className={`py-5 ${isReplyType && "flex tablet:gap-5 gap-2"}`}>
           {isReplyType && <ReplyIcon />}
-          <article className="w-full flex flex-col gap-3">
-            <div className="flex items-center justify-between">
-              <CommentAuthInfo
-                author={author.nickname}
-                profileImage={author.imageUrl}
-                createdAt={createdAt}
-              />
-              {actions.length > 0 && !isReplying && (
-                <Actions actions={actions} />
-              )}
-            </div>
+          <article className="w-full flex flex-col gap-2">
+            {published && (
+              <section className="flex items-center justify-between">
+                <CommentAuthInfo
+                  author={author.nickname}
+                  profileImage={author.imageUrl}
+                  isPostAuthor={isPostAuthor}
+                />
+                {actions.length > 0 && !isReplying && (
+                  <Actions actions={actions} />
+                )}
+              </section>
+            )}
             {isEditing ? (
               <CommentForm
                 type="edit"
@@ -123,9 +132,18 @@ export default function CommentListItem({
                 onSuccess={onEditSuccess}
               />
             ) : (
-              <p className="px-5 text-body-2 font-medium text-black-100 leading-6">
-                {content}
-              </p>
+              <div className="px-9">
+                <p
+                  className={`text-body-1 font-medium ${
+                    published ? "text-black-200 mb-1" : "text-gray-400"
+                  } leading-6`}
+                >
+                  {content}
+                </p>
+                {published && (
+                  <PostTime type="comment" time={createdAt} size="default" />
+                )}
+              </div>
             )}
           </article>
         </div>
@@ -137,10 +155,10 @@ export default function CommentListItem({
         comment.replies.map((reply) => (
           <ul key={reply.id}>
             <CommentListItem
+              postAuthorId={postAuthorId}
               commentActionState={commentActionState}
               comment={reply}
               isReplyType
-              // onAction={onAction}
             />
           </ul>
         ))}
@@ -151,9 +169,10 @@ export default function CommentListItem({
             <ReplyIcon />
             <div className="w-full">
               <div className="mb-3 flex items-center justify-between">
-                <CommentUserProfile
+                <CommentAuthInfo
                   author={user.nickname}
                   profileImage={user.imageUrl}
+                  size={36}
                 />
                 <Actions actions={actions} />
               </div>

--- a/src/components/domains/postDetail/commentSection/comment/postComment.types.ts
+++ b/src/components/domains/postDetail/commentSection/comment/postComment.types.ts
@@ -22,8 +22,8 @@ export type TComment = {
 export interface ICommentIListProps {
   commentList: CommentResponse[];
   onLoadMore: () => void;
-  onAction: (action: CommentAction) => void;
-  nextCursor?: string | null;
+  // onAction: (action: CommentAction) => void;
+  hasNextCursor?: boolean;
   isLoadingComments?: boolean;
 }
 
@@ -34,7 +34,7 @@ export interface ICommentFormProps {
   commentId?: string;
   postId: string;
   parentId?: string | null;
-  onSuccess?: (action: CommentAction) => void;
+  onSuccess?: () => void;
   onCancel?: () => void;
 }
 

--- a/src/components/domains/postDetail/commentSection/comment/postComment.types.ts
+++ b/src/components/domains/postDetail/commentSection/comment/postComment.types.ts
@@ -1,18 +1,15 @@
 import { CommentResponse } from "@/lib/hono/schemas/comment.schema";
-import { CommentAction } from "../comment.reducer";
 
-export interface ICommentAuthProfileProps {
+export interface ICommentAuthInfoProps {
   author: string;
   profileImage?: string | null;
-}
-
-export interface ICommentAuthInfoProps extends ICommentAuthProfileProps {
-  createdAt: string;
+  size?: number;
+  isPostAuthor?: boolean;
 }
 
 export type TComment = {
   id: string;
-  authInfo: ICommentAuthProfileProps;
+  authInfo: ICommentAuthInfoProps;
   content: string;
   createdAt: string;
   isAuthor: boolean;
@@ -22,9 +19,9 @@ export type TComment = {
 export interface ICommentIListProps {
   commentList: CommentResponse[];
   onLoadMore: () => void;
-  // onAction: (action: CommentAction) => void;
   hasNextCursor?: boolean;
   isLoadingComments?: boolean;
+  postAuthorId: string;
 }
 
 export interface ICommentFormProps {

--- a/src/components/domains/postDetail/commentSection/index.tsx
+++ b/src/components/domains/postDetail/commentSection/index.tsx
@@ -3,81 +3,59 @@ import { CommentResponse } from "@/lib/hono/schemas/comment.schema";
 import CommentForm from "./comment/CommentForm";
 import CommentIList from "./comment/CommentIList";
 import { SearchResponse } from "@/lib/hooks/useInfinityScroll";
-import { useReducer, useState } from "react";
 import { getCommentsByPostId } from "./comment.helper";
-import {
-  ADD_NEW_COMMENT,
-  ADD_NEW_REPLY,
-  CommentAction,
-  commentsReducer,
-  DELETE_COMMENT,
-} from "./comment.reducer";
+import { InfiniteData, useInfiniteQuery } from "@tanstack/react-query";
+import { ApiSuccessResponse } from "@/lib/hono/utils/response.constants";
 
 interface ICommentSectionProps {
   postId: string;
-  initialCommentsResult: SearchResponse<CommentResponse>;
   totalCommentCount: number;
-  changeCommentCount: (change: 1 | -1) => void;
 }
 export default function CommentSection({
   postId,
-  initialCommentsResult,
-  changeCommentCount,
   totalCommentCount,
 }: ICommentSectionProps) {
-  const [commentList, dispatch] = useReducer(
-    commentsReducer,
-    initialCommentsResult.data || []
-  );
+  const {
+    data: commentResult,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading,
+    isError,
+  } = useInfiniteQuery<
+    ApiSuccessResponse<SearchResponse<CommentResponse>>,
+    Error,
+    InfiniteData<ApiSuccessResponse<SearchResponse<CommentResponse>>>,
+    string[],
+    string | null
+  >({
+    queryKey: ["post", postId, "comments"],
+    queryFn: ({ pageParam }) => getCommentsByPostId(postId, pageParam),
+    initialPageParam: null,
+    getNextPageParam: (lastPage) => {
+      return lastPage?.data?.nextCursor || undefined;
+    },
+  });
 
-  const [isLoadingComments, setIsLoadingComments] = useState(false);
-  const [nextCursor, setNextCursor] = useState(
-    initialCommentsResult.nextCursor
-  );
+  const commentList =
+    commentResult?.pages.flatMap((page) => page.data.data) || [];
 
-  const handleLoadMoreComments = async () => {
-    if (isLoadingComments || !nextCursor) return;
-    setIsLoadingComments(true);
-    try {
-      const response = await getCommentsByPostId(postId, nextCursor);
-      const result = response.data;
-      dispatch({ type: "ADD_MORE_COMMENTS", payload: result.data });
-
-      setNextCursor(result.nextCursor);
-    } catch (error) {
-      console.error("Error loading more comments:", error);
-    } finally {
-      setIsLoadingComments(false);
-    }
-  };
-
-  const handleCommentActions = (action: CommentAction) => {
-    dispatch(action);
-    if (action.type === ADD_NEW_COMMENT || action.type === ADD_NEW_REPLY) {
-      changeCommentCount(1);
-    }
-    if (action.type === DELETE_COMMENT) {
-      changeCommentCount(-1);
-    }
-  };
+  if (isError) {
+    return <div>댓글을 불러오는 중 오류가 발생했습니다.</div>;
+  }
 
   return (
     <section className="px-4">
       <h2 className="text-title-2 tablet:text-headline-3 font-semibold text-black-100">
         댓글 {totalCommentCount}
       </h2>
-      <CommentForm
-        type="create"
-        postId={postId}
-        onSuccess={handleCommentActions}
-      />
-      {commentList.length > 0 && (
+      <CommentForm type="create" postId={postId} />
+      {!isLoading && commentList.length > 0 && (
         <CommentIList
-          isLoadingComments={isLoadingComments}
-          nextCursor={nextCursor}
+          isLoadingComments={isFetchingNextPage}
+          hasNextCursor={hasNextPage}
           commentList={commentList}
-          onLoadMore={handleLoadMoreComments}
-          onAction={handleCommentActions}
+          onLoadMore={fetchNextPage}
         />
       )}
     </section>

--- a/src/components/domains/postDetail/commentSection/index.tsx
+++ b/src/components/domains/postDetail/commentSection/index.tsx
@@ -9,10 +9,12 @@ import { ApiSuccessResponse } from "@/lib/hono/utils/response.constants";
 
 interface ICommentSectionProps {
   postId: string;
+  postAuthorId: string;
   totalCommentCount: number;
 }
 export default function CommentSection({
   postId,
+  postAuthorId,
   totalCommentCount,
 }: ICommentSectionProps) {
   const {
@@ -52,6 +54,7 @@ export default function CommentSection({
       <CommentForm type="create" postId={postId} />
       {!isLoading && commentList.length > 0 && (
         <CommentIList
+          postAuthorId={postAuthorId}
           isLoadingComments={isFetchingNextPage}
           hasNextCursor={hasNextPage}
           commentList={commentList}

--- a/src/components/domains/postDetail/commentSection/useCommentMutation.ts
+++ b/src/components/domains/postDetail/commentSection/useCommentMutation.ts
@@ -1,0 +1,32 @@
+import { CreateCommentBody } from "@/lib/hono/schemas/comment.schema";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createNewComment, deleteCommentById } from "./comment.helper";
+
+export default function useCommentMutation(postId: string) {
+  const queryClient = useQueryClient();
+  const invalidateComments = () =>
+    queryClient.invalidateQueries({ queryKey: ["post", postId, "comments"] });
+  const invalidatePostStatus = () =>
+    queryClient.invalidateQueries({ queryKey: ["post", postId, "status"] });
+
+  const uploadMutation = useMutation({
+    mutationFn: (commentData: CreateCommentBody) =>
+      createNewComment(postId, commentData),
+    onSuccess: () => {
+      invalidateComments();
+      invalidatePostStatus();
+    },
+    onError: (error) => console.error(error, error.message),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (commentId: string) => deleteCommentById(commentId),
+    onSuccess: () => {
+      invalidateComments();
+      invalidatePostStatus();
+    },
+    onError: (error) => console.error(error, error.message),
+  });
+
+  return { uploadMutation, deleteMutation };
+}

--- a/src/components/domains/postDetail/postDetail.helpers.ts
+++ b/src/components/domains/postDetail/postDetail.helpers.ts
@@ -10,13 +10,12 @@ export const COMMUNITY_URL = `${API_BASE_URL}/community/posts`;
 
 export async function getPostDetailById(
   postId: string,
-  headers: HeadersInit
-): Promise<ApiSuccessResponse<PostDetailResponse>> {
+  headers?: HeadersInit
+): Promise<PostDetailResponse> {
   try {
     const response = await fetch(`${COMMUNITY_URL}/${postId}`, {
       method: "GET",
-      next: { revalidate: 300 },
-      headers: headers,
+      ...(headers && { headers }),
     });
 
     if (!response.ok) {
@@ -42,7 +41,7 @@ export async function getPostDetailById(
     }
 
     const result = await response.json();
-    return result;
+    return result.data;
   } catch (error) {
     console.error(`Error fetching post ${postId}:`, error);
     throw error;
@@ -51,13 +50,13 @@ export async function getPostDetailById(
 
 export async function getPostDetailStatusById(
   postId: string,
-  headers: HeadersInit
-): Promise<ApiSuccessResponse<PostStatusResponse>> {
+  headers?: HeadersInit
+): Promise<PostStatusResponse> {
   try {
     const response = await fetch(`${COMMUNITY_URL}/${postId}/status`, {
       method: "GET",
       cache: "no-store",
-      headers: headers,
+      ...(headers && { headers }),
     });
 
     if (!response.ok) {
@@ -84,7 +83,7 @@ export async function getPostDetailStatusById(
 
     const result = await response.json();
 
-    return result;
+    return result.data;
   } catch (error) {
     console.error("Error fetching post status:", error);
     throw error;
@@ -117,7 +116,6 @@ export async function toggleBookmarkedPostById(
   try {
     const response = await fetch(`${COMMUNITY_URL}/${postId}/bookmark`, {
       method: "POST",
-      cache: "no-store",
     });
     if (!response.ok) {
       const errorText = await response.text();

--- a/src/lib/hono/routes/v1/comment.handler.ts
+++ b/src/lib/hono/routes/v1/comment.handler.ts
@@ -13,6 +13,7 @@ import {
   apiConflict,
   apiBadRequest,
   apiCreated,
+  apiForbidden,
 } from "../../utils/apiResponse.utils";
 
 const commentsApi = new OpenAPIHono<AppContext>();
@@ -161,3 +162,44 @@ commentsApi.openapi(createCommentRoute, async (c) => {
 commentsApi.route("/", authenticatedApi);
 
 export default commentsApi;
+
+/** * @method DELETE
+ * @path /{commentId}
+ * @summary 댓글 삭제
+ */
+const deleteCommentRoute = createRoute({
+  method: "delete",
+  path: "/{commentId}",
+  summary: "댓글 삭제 (Soft Delete)",
+  description: `댓글 또는 대댓글을 삭제합니다. 댓글 내용을 "삭제된 댓글 입니다."로 변경하고, published 필드를 false로 설정합니다.`,
+  request: {
+    params: CommentSchemas.CommentIdParamSchema,
+  },
+  responses: createStandardApiResponses(
+    {
+      schema: CommentSchemas.DeleteCommentResponseSchema,
+      description: "댓글",
+    },
+    ["400", "401", "403", "404"]
+  ),
+  tags: ["Comment"],
+});
+
+commentsApi.use(deleteCommentRoute.getRoutingPath(), authMiddleware);
+
+commentsApi.openapi(deleteCommentRoute, async (c) => {
+  const { commentId } = c.req.valid("param");
+  const user = await getAuthenticatedUser(c);
+  const payload: CommentSchemas.DeleteCommentPayload = {
+    id: commentId,
+    authorId: user.id,
+  };
+  const result = await CommentServices.deleteCommentService(payload);
+  if (!result.success) {
+    if (result.error === "NOT_FOUND") return apiNotFound(c, result.message);
+    if (result.error === "FORBIDDEN") return apiForbidden(c, result.message);
+    if (result.error === "BAD_REQUEST") return apiBadRequest(c, result.message);
+    return apiInternalError(c, result.message);
+  }
+  return apiSuccess(c, result.data, "댓글을 성공적으로 삭제했습니다.");
+});

--- a/src/lib/hono/schemas/comment.schema.ts
+++ b/src/lib/hono/schemas/comment.schema.ts
@@ -39,6 +39,22 @@ export const PaginatedCommentResponseSchema = z.object({
   totalCount: z.number().optional(),
 });
 
+export const DeleteCommentPayloadSchema = CommentSchema.pick({
+  id: true,
+  authorId: true,
+});
+
+export const DELETED_COMMENT_MESSAGE_BY_USER = "삭제된 댓글입니다.";
+
+export const DeleteCommentResponseSchema = CommentResponseSchema.extend({
+  published: z.literal(false),
+  content: z.literal(DELETED_COMMENT_MESSAGE_BY_USER),
+});
+
+export const CommentIdParamSchema = z.object({
+  commentId: z.string().uuid("유효하지 않은 댓글 ID입니다."),
+});
+
 export type GetCommentQuery = z.infer<typeof GetCommentQuerySchema>;
 export type CommentReplyResponse = z.infer<typeof ReplyResponseSchema>;
 export type CommentResponse = z.infer<typeof CommentResponseSchema>;
@@ -47,3 +63,6 @@ export type PaginatedCommentResponse = z.infer<
 >;
 export type CreateCommentBody = z.infer<typeof CreateCommentBodySchema>;
 export type CreateCommentPayload = z.infer<typeof CreateCommentPayloadSchema>;
+
+export type DeleteCommentPayload = z.infer<typeof DeleteCommentPayloadSchema>;
+export type DeleteCommentResponse = z.infer<typeof DeleteCommentResponseSchema>;

--- a/src/lib/hono/services/comment.service.ts
+++ b/src/lib/hono/services/comment.service.ts
@@ -88,26 +88,52 @@ export const getPaginatedCommentService = async (
       parentId: null,
     };
 
-    const [comments, totalCount] = await Promise.all([
+    const [commentsFromDb, totalCount] = await Promise.all([
       prisma.comment.findMany({
         where,
         ...commentWithRepliesArgs,
         orderBy: {
           createdAt: "desc",
         },
-        cursor: cursor ? { id: cursor } : undefined,
+        ...(cursor && {
+          cursor: { id: cursor },
+          skip: 1,
+        }),
         take: limit + 1,
       }),
-      prisma.comment.count({ where }),
+      prisma.comment.count({ where: { ...where, published: true } }),
     ]);
 
     const paginatedResult = createCursorPaginationResult(
-      comments,
+      commentsFromDb,
       totalCount,
       limit
     );
 
-    const formattedData = paginatedResult.data.map((comment) => ({
+    const comments = paginatedResult.data
+      .map((comment) => {
+        const filteredReplies = comment.replies.filter(
+          (reply) => reply.published
+        );
+        comment.replies = filteredReplies;
+        if (comment.published) {
+          return comment;
+        }
+        if (!comment.published && comment.replies.length > 0) {
+          return {
+            ...comment,
+            author: {
+              id: comment.author.id,
+              nickname: "알 수 없음",
+              imageUrl: null,
+            },
+          };
+        }
+        return null;
+      })
+      .filter(Boolean) as CommentWithReplies[];
+
+    const formattedData = comments.map((comment) => ({
       ...comment,
       createdAt: comment.createdAt.toISOString(),
       updatedAt: comment.updatedAt?.toISOString() || null,

--- a/src/lib/hono/services/comment.service.ts
+++ b/src/lib/hono/services/comment.service.ts
@@ -1,13 +1,18 @@
 import { prisma } from "@/lib/prisma";
 import { Prisma } from "@prisma/client";
-import { checkResourceExists } from "../utils/service.utils";
+import { checkResourceExists, validateUuid } from "../utils/service.utils";
 import {
+  serviceBadRequest,
+  serviceForbidden,
   serviceInternalError,
+  serviceNotFound,
   ServiceResult,
   serviceSuccess,
 } from "../utils/serviceResult.utils";
 import {
   CreateCommentPayload,
+  DeleteCommentPayload,
+  DELETED_COMMENT_MESSAGE_BY_USER,
   GetCommentQuery,
   PaginatedCommentResponse,
 } from "../schemas/comment.schema";
@@ -160,6 +165,65 @@ export const createCommentService = async (
     });
 
     return serviceSuccess(newComment);
+  } catch (error) {
+    return serviceInternalError(error);
+  }
+};
+
+/** * 댓글 또는 대댓글을 삭제합니다.(softDelete) 댓글 내용을 "삭제된 댓글 입니다."로 변경하고, published 필드를 false로 설정합니다.
+ * @param params - 삭제할 댓글의 ID와 작성자 ID
+ */
+export const deleteCommentService = async (
+  params: DeleteCommentPayload
+): Promise<ServiceResult<CommentWithReplies>> => {
+  try {
+    const { id: commentId, authorId } = params;
+    const uuidValidation = validateUuid(commentId, "댓글");
+    if (!uuidValidation.success) return uuidValidation;
+
+    const existenceCheck = await checkResourceExists(
+      "comment",
+      commentId,
+      "댓글"
+    );
+    if (!existenceCheck.success) return existenceCheck;
+    const comment = await prisma.comment.findUnique({
+      where: { id: commentId },
+      select: { authorId: true, postId: true, published: true },
+    });
+    if (!comment || comment.authorId !== authorId) {
+      return serviceForbidden("댓글을 삭제할 권한이 없습니다.");
+    }
+    if (!comment.published) {
+      return serviceBadRequest("이미 삭제된 댓글입니다.");
+    }
+
+    await prisma.$transaction(async (tx) => {
+      await tx.comment.update({
+        where: { id: commentId },
+        data: {
+          published: false,
+          content: DELETED_COMMENT_MESSAGE_BY_USER,
+        },
+      });
+      await tx.post.update({
+        where: {
+          id: comment.postId,
+        },
+        data: {
+          commentCount: { decrement: 1 },
+        },
+      });
+    });
+    const deletedComment = await prisma.comment.findUnique({
+      where: { id: commentId },
+      ...commentWithRepliesArgs,
+    });
+    if (!deletedComment) {
+      return serviceNotFound("댓글을 찾을 수 없습니다.");
+    }
+
+    return serviceSuccess(deletedComment);
   } catch (error) {
     return serviceInternalError(error);
   }

--- a/src/lib/hono/utils/getQueryClient.ts
+++ b/src/lib/hono/utils/getQueryClient.ts
@@ -1,0 +1,6 @@
+import { QueryClient } from "@tanstack/react-query";
+import { cache } from "react";
+
+const getQueryClient = cache(() => new QueryClient());
+
+export default getQueryClient;


### PR DESCRIPTION
### 📌요구사항

- [x] 댓글 삭제 api 구현 및 연동
- [x] 커뮤니티 상세페이지 기존 데이터 fetching 로직을 TanStack Query로 전환

### 📌작업 진행 상황 (에러, 막혔던 부분, 그외 궁금한것 등등)

커뮤니티 상세페이지 남은것
- 댓글 수정 api 구현 및 연동
- 북마크, 좋아요 api TanStack Query로 전환
- 하단 부 게시판 게시글 목록 추가


### 📌스크린샷 / 테스트결과 (선택)

https://github.com/user-attachments/assets/730037a0-d8ef-41b0-996c-d1262a4d9638


<img width="2134" height="1188" alt="image" src="https://github.com/user-attachments/assets/676ded8a-c965-4a4b-8192-0f7d05434970" />

### 📌이슈 번호
#70