### PR TITLE
Feat: 게시글 수정 페이지 구현 및 api 연동

### DIFF
--- a/src/app/community/post/[id]/edit/page.tsx
+++ b/src/app/community/post/[id]/edit/page.tsx
@@ -1,0 +1,41 @@
+import PageClient from "@/components/domains/post/PageClient";
+import { getPostDetailById } from "@/components/domains/postDetail/postDetail.helpers";
+import { getSession } from "@/lib/database/getSession";
+import getQueryClient from "@/lib/hono/utils/getQueryClient";
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
+import { cookies } from "next/headers";
+import { notFound } from "next/navigation";
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const session = await getSession();
+  if (!session) {
+    return <div>로그인이 필요한 서비스 입니다.</div>; //로그인 하지 않은경우 로그인 모달띄우기
+  }
+  const cookieStore = await cookies();
+
+  const requestHeaders = {
+    Cookie: cookieStore.toString(),
+  };
+  const queryClient = getQueryClient();
+
+  const post = await queryClient.fetchQuery({
+    queryKey: ["post", id],
+    queryFn: () => getPostDetailById(id, requestHeaders),
+  });
+
+  if (!post || post.author.id !== session.user?.id) {
+    return notFound();
+  }
+
+  const dehydratedState = dehydrate(queryClient);
+
+  return (
+    <HydrationBoundary state={dehydratedState}>
+      <PageClient type="edit" postId={id} />
+    </HydrationBoundary>
+  );
+}

--- a/src/app/community/post/page.tsx
+++ b/src/app/community/post/page.tsx
@@ -1,5 +1,12 @@
 import PageClient from "@/components/domains/post/PageClient";
+import { getSession } from "@/lib/database/getSession";
 export default async function Page() {
+  const session = await getSession();
+
+  if (!session) {
+    return <div>로그인이 필요한 서비스 입니다.</div>; //로그인 하지 않은경우 로그인 모달띄우기
+  }
+
   return (
     <>
       <PageClient type="create" />

--- a/src/components/domains/post/PageClient.tsx
+++ b/src/components/domains/post/PageClient.tsx
@@ -1,27 +1,57 @@
 "use client";
 
-import PostForm from "./form";
+import { useQuery } from "@tanstack/react-query";
+import PostForm, { TPostFormInitialData } from "./form";
 import Header from "./header";
-import { CreatePostInput } from "@/lib/hono/schemas/community.schema";
+import { getPostDetailById } from "../postDetail/postDetail.helpers";
+import { useUserStore } from "@/lib/stores/useUserStore";
+import { useRouter } from "next/navigation";
+// import { Spinner } from "@/components/commons/loading/Spinner";
+// import { useEffect } from "react";
 
 interface IPostFormPageProps {
   type: "create" | "edit";
-  initialData?: CreatePostInput;
+  postId?: string;
 }
 
-export default function PageClient({ type, initialData }: IPostFormPageProps) {
-  // const { user } = useUserStore();
-  // if (!user) {
-  //   return (
-  //     <div className="w-full h-screen flex items-center justify-center">
-  //       <p className="text-lg text-gray-600">로그인이 필요합니다.</p>
-  //     </div>
-  //   );
+export default function PageClient({ type, postId }: IPostFormPageProps) {
+  const { user, isLoading: isAuthLoading } = useUserStore();
+  const router = useRouter();
+
+  const { data: post, isError } = useQuery({
+    queryKey: ["post", postId],
+    queryFn: () => getPostDetailById(postId!),
+    enabled: type === "edit" && !!postId && !!user,
+  });
+
+  // useEffect(() => {
+  //   if (!isAuthLoading && !user) {
+  //     router.replace("/");
+  //   }
+  // }, [isAuthLoading, user, router]);
+
+  // if (isAuthLoading || !user) {
+  //   return <Spinner />;
   // }
+
+  if (isError) return <div>데이터를 불러오는 데 실패했습니다.</div>;
+
+  const initialData: TPostFormInitialData | undefined =
+    type === "edit" && post
+      ? {
+          category: post.category,
+          title: post.title,
+          content: post.content,
+          thumbnailUrl: post.thumbnailUrl,
+          contentText: post.contentText,
+          perfumes: post.perfumes || [],
+        }
+      : undefined;
+
   return (
     <div className="px-4 w-full flex flex-col items-center gap-5 pb-[150px]">
-      <Header />
-      <PostForm type={type} initialData={initialData} />
+      <Header type={type} />
+      <PostForm type={type} initialData={initialData} postId={postId} />
     </div>
   );
 }

--- a/src/components/domains/post/PageClient.tsx
+++ b/src/components/domains/post/PageClient.tsx
@@ -5,9 +5,6 @@ import PostForm, { TPostFormInitialData } from "./form";
 import Header from "./header";
 import { getPostDetailById } from "../postDetail/postDetail.helpers";
 import { useUserStore } from "@/lib/stores/useUserStore";
-import { useRouter } from "next/navigation";
-// import { Spinner } from "@/components/commons/loading/Spinner";
-// import { useEffect } from "react";
 
 interface IPostFormPageProps {
   type: "create" | "edit";
@@ -16,7 +13,6 @@ interface IPostFormPageProps {
 
 export default function PageClient({ type, postId }: IPostFormPageProps) {
   const { user, isLoading: isAuthLoading } = useUserStore();
-  const router = useRouter();
 
   const { data: post, isError } = useQuery({
     queryKey: ["post", postId],
@@ -24,15 +20,9 @@ export default function PageClient({ type, postId }: IPostFormPageProps) {
     enabled: type === "edit" && !!postId && !!user,
   });
 
-  // useEffect(() => {
-  //   if (!isAuthLoading && !user) {
-  //     router.replace("/");
-  //   }
-  // }, [isAuthLoading, user, router]);
-
-  // if (isAuthLoading || !user) {
-  //   return <Spinner />;
-  // }
+  if (isAuthLoading || !user) {
+    return <div>로그인이 필요한 서비스 입니다.</div>;
+  }
 
   if (isError) return <div>데이터를 불러오는 데 실패했습니다.</div>;
 

--- a/src/components/domains/post/form/index.tsx
+++ b/src/components/domains/post/form/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useRef, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRef } from "react";
+
 import PostEditor from "./PostEditor";
 import PostFormActions from "./PostFormActions";
 import PostTitle from "./PostTitle";
@@ -9,8 +9,6 @@ import { extractFirstImageSrc } from "@/lib/utils/extractFirstImageSrc";
 import { useForm, FormProvider } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import PostCategory from "./PostCategory";
-import { submitNewPost } from "../post.helpers";
-
 import getPlainText from "@/lib/utils/getPlainText";
 import { PostCategory as TPostCategory } from "@prisma/client";
 import PostRelatedPerfume from "./postRelatedPerfume/PostRelatedPerfume";
@@ -37,8 +35,6 @@ export default function PostForm({
   initialData,
   postId,
 }: IPostFormProps) {
-  const router = useRouter();
-
   const blobRegistryRef = useRef<BlobRegistry>(new Map());
 
   const method = useForm<CreatePostInput>({

--- a/src/components/domains/post/form/index.tsx
+++ b/src/components/domains/post/form/index.tsx
@@ -21,6 +21,7 @@ import {
   CreatePostInputSchema,
   PerfumeForPost,
 } from "@/lib/hono/schemas/community.schema";
+import usePostMutation from "../usePostMutation";
 
 export type TPostFormInitialData = CreatePostInput & {
   perfumes: PerfumeForPost[] | [];
@@ -31,9 +32,13 @@ interface IPostFormProps {
   postId?: string;
 }
 
-export default function PostForm({ type, initialData }: IPostFormProps) {
+export default function PostForm({
+  type,
+  initialData,
+  postId,
+}: IPostFormProps) {
   const router = useRouter();
-  const [isLoading, setIsLoading] = useState(false);
+
   const blobRegistryRef = useRef<BlobRegistry>(new Map());
 
   const method = useForm<CreatePostInput>({
@@ -54,35 +59,28 @@ export default function PostForm({ type, initialData }: IPostFormProps) {
     setValue,
   } = method;
 
+  const { createMutation, editMutation } = usePostMutation(postId);
+  const isLoading = createMutation.isPending || editMutation.isPending;
+
   const onSubmit = async (data: CreatePostInput) => {
-    setIsLoading(true);
+    const finalizedContent = await finalizeWithBlobRegistry(
+      data.content,
+      blobRegistryRef.current
+    );
+    setValue("content", finalizedContent, { shouldDirty: true });
+    const thumbnailUrl = extractFirstImageSrc(finalizedContent);
+    const contentText = getPlainText(finalizedContent);
+    const postData: CreatePostInput = {
+      ...data,
+      content: finalizedContent,
+      thumbnailUrl,
+      contentText,
+    };
 
-    try {
-      const finalizedContent = await finalizeWithBlobRegistry(
-        data.content,
-        blobRegistryRef.current
-      );
-      setValue("content", finalizedContent, { shouldDirty: true });
-      const thumbnailUrl = extractFirstImageSrc(finalizedContent);
-      const contentText = getPlainText(finalizedContent);
-      const postData: CreatePostInput = {
-        ...data,
-        content: finalizedContent,
-        thumbnailUrl,
-        contentText,
-      };
-
-      if (type === "create") {
-        const result = await submitNewPost(postData);
-        if (result.success && result.data) {
-          router.push(`/community/post/${result.data.id}`);
-        }
-      }
-      //게시글 수정 추가
-    } catch (error) {
-      console.error("Error submitting new post:", error);
-    } finally {
-      setIsLoading(false);
+    if (type === "create") {
+      createMutation.mutate(postData);
+    } else if (type === "edit") {
+      editMutation.mutate(postData);
     }
   };
 

--- a/src/components/domains/post/form/index.tsx
+++ b/src/components/domains/post/form/index.tsx
@@ -19,11 +19,16 @@ import type { BlobRegistry } from "@/lib/ckeditor/localPreviewUploadPlugin";
 import {
   CreatePostInput,
   CreatePostInputSchema,
+  PerfumeForPost,
 } from "@/lib/hono/schemas/community.schema";
 
+export type TPostFormInitialData = CreatePostInput & {
+  perfumes: PerfumeForPost[] | [];
+};
 interface IPostFormProps {
   type: "create" | "edit";
-  initialData?: CreatePostInput;
+  initialData?: TPostFormInitialData;
+  postId?: string;
 }
 
 export default function PostForm({ type, initialData }: IPostFormProps) {
@@ -40,9 +45,9 @@ export default function PostForm({ type, initialData }: IPostFormProps) {
       content: initialData?.content ?? "",
       contentText: initialData?.contentText ?? "",
       thumbnailUrl: initialData?.thumbnailUrl ?? null,
-      perfumeIds: initialData?.perfumeIds,
     },
   });
+
   const {
     handleSubmit,
     formState: { isValid, isDirty },
@@ -93,7 +98,7 @@ export default function PostForm({ type, initialData }: IPostFormProps) {
           <PostCategory />
           <PostTitle />
           <PostEditor blobRegistryRef={blobRegistryRef} />
-          <PostRelatedPerfume />
+          <PostRelatedPerfume initialPerfumes={initialData?.perfumes} />
         </div>
         <PostFormActions disabled={disabled} />
       </form>

--- a/src/components/domains/post/form/postRelatedPerfume/PostRelatedPerfume.tsx
+++ b/src/components/domains/post/form/postRelatedPerfume/PostRelatedPerfume.tsx
@@ -3,7 +3,7 @@ import SubTitleLabel from "../element/SubTitleLabel";
 import InputBase from "@/components/commons/input";
 import { SearchResultsDropdown } from "@/components/commons/dropdown/SearchResultsDropdown";
 import PerfumeResultItem from "./PerfumeResultItem";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useVisibilityStore } from "@/lib/stores/useVisibilityStore";
 import PerfumeCard from "@/components/commons/card/perfumeCard";
 import useOnClickOutside from "@/lib/hooks/useOnClickOutside";
@@ -11,8 +11,14 @@ import useDebounce from "@/lib/hooks/useDebounce";
 import { useFormContext } from "react-hook-form";
 import { searchPerfumesByName } from "../../post.helpers";
 import usePerfumeSearch from "./usePerfumeSearch";
+import { PerfumeForPost } from "@/lib/hono/schemas/community.schema";
 
-export default function PostRelatedPerfume() {
+interface IPostRelatedPerfumeProps {
+  initialPerfumes?: PerfumeForPost[] | [];
+}
+export default function PostRelatedPerfume({
+  initialPerfumes,
+}: IPostRelatedPerfumeProps) {
   const { setValue } = useFormContext();
   const {
     searchQuery,
@@ -20,11 +26,12 @@ export default function PostRelatedPerfume() {
     searchResults,
     setSearchResults,
     selectedPerfumes,
+
     tempSelectedPerfumeIds,
     handleToggleTempSelect,
     handleAddSelectedPerfumes,
     handleRemoveSelectedPerfume,
-  } = usePerfumeSearch();
+  } = usePerfumeSearch(initialPerfumes);
 
   const debouncedSearchQuery = useDebounce(searchQuery, 1000);
   const [isLoading, setIsLoading] = useState(false);
@@ -34,7 +41,10 @@ export default function PostRelatedPerfume() {
   const searchContainerRef = useRef<HTMLDivElement>(null);
   useOnClickOutside(searchContainerRef, () => close(dropdownId));
 
-  const selectedPerfumesIds = selectedPerfumes.map((p) => p.id);
+  const selectedPerfumesIds = useMemo(
+    () => selectedPerfumes.map((p) => p.id),
+    [selectedPerfumes]
+  );
   const MAX_SELECTED_PERFUMES = 8;
   const isSelectedPerfumesLimit =
     selectedPerfumesIds.length + tempSelectedPerfumeIds.length >=
@@ -42,7 +52,7 @@ export default function PostRelatedPerfume() {
 
   useEffect(() => {
     setValue("perfumeIds", selectedPerfumesIds);
-  }, [selectedPerfumes, setValue, selectedPerfumesIds]);
+  }, [setValue, selectedPerfumesIds]);
 
   useEffect(() => {
     const fetchAndSetResults = async () => {

--- a/src/components/domains/post/form/postRelatedPerfume/usePerfumeSearch.ts
+++ b/src/components/domains/post/form/postRelatedPerfume/usePerfumeSearch.ts
@@ -2,7 +2,9 @@ import { ApiPerfumeSimpleResponse } from "@/lib/hono/schemas/perfume.schema";
 
 import { useState } from "react";
 
-export default function usePerfumeSearch() {
+export default function usePerfumeSearch(
+  initialPerfumes?: ApiPerfumeSimpleResponse[]
+) {
   const [searchQuery, setSearchQuery] = useState("");
   const [searchResults, setSearchResults] = useState<
     ApiPerfumeSimpleResponse[]
@@ -13,7 +15,7 @@ export default function usePerfumeSearch() {
   >([]);
   const [selectedPerfumes, setSelectedPerfumes] = useState<
     ApiPerfumeSimpleResponse[]
-  >([]);
+  >(initialPerfumes || []);
 
   const handleToggleTempSelect = (perfume: ApiPerfumeSimpleResponse) => {
     setTempSelectedPerfumesIds((prev) => {

--- a/src/components/domains/post/header/index.tsx
+++ b/src/components/domains/post/header/index.tsx
@@ -1,10 +1,10 @@
 import CautionCard from "./CautionCard";
 
-export default function Header() {
+export default function Header({ type }: { type: "edit" | "create" }) {
   return (
     <header className="w-full mt-6  tablet:my-10">
       <h1 className="mb-10 text-black-100 font-bold text-headline-2 tablet:text-headline-1 text-center">
-        글 작성
+        글 {type === "create" ? "작성" : "수정"}
       </h1>
       <CautionCard />
     </header>

--- a/src/components/domains/post/post.helpers.ts
+++ b/src/components/domains/post/post.helpers.ts
@@ -56,6 +56,6 @@ export async function searchPerfumesByName(
 export async function editPostById(
   postId: string,
   postFormData: UpdatePostInput
-): Promise<ApiPostResponse | null> {
+): Promise<ApiSuccessResponse<ApiPostResponse> | null> {
   return await apiClient.patch(`/community/posts/${postId}`, postFormData);
 }

--- a/src/components/domains/post/post.helpers.ts
+++ b/src/components/domains/post/post.helpers.ts
@@ -1,10 +1,16 @@
 import {
   CreatePostInput,
   ApiPostResponse,
+  UpdatePostInput,
 } from "@/lib/hono/schemas/community.schema";
 import { API_BASE_URL, COMMUNITY_URL } from "../postDetail/postDetail.helpers";
 import { ApiSuccessResponse } from "@/lib/hono/utils/response.constants";
 import { ApiPerfumeSimpleResponse } from "@/lib/hono/schemas/perfume.schema";
+import { createHttpClient } from "@/lib/utils/core-request";
+
+const apiClient = createHttpClient({
+  baseUrl: process.env.NEXT_PUBLIC_API_BASE_URL || API_BASE_URL,
+});
 
 export async function submitNewPost(
   postFormData: CreatePostInput
@@ -45,4 +51,11 @@ export async function searchPerfumesByName(
     console.error("searchPerfumesByName 오류:", error);
     throw error;
   }
+}
+
+export async function editPostById(
+  postId: string,
+  postFormData: UpdatePostInput
+): Promise<ApiPostResponse | null> {
+  return await apiClient.patch(`/community/posts/${postId}`, postFormData);
 }

--- a/src/components/domains/post/usePostMutation.ts
+++ b/src/components/domains/post/usePostMutation.ts
@@ -29,7 +29,7 @@ export default function usePostMutation(postId?: string) {
   const editMutation = useMutation({
     mutationFn: (updatedPost: UpdatePostInput) =>
       editPostById(postId!, updatedPost),
-    onSuccess: (data) => {
+    onSuccess: () => {
       invalidatePost();
       router.push(`/community/post/${postId}`);
     },

--- a/src/components/domains/post/usePostMutation.ts
+++ b/src/components/domains/post/usePostMutation.ts
@@ -1,0 +1,40 @@
+import {
+  CreatePostInput,
+  UpdatePostInput,
+} from "@/lib/hono/schemas/community.schema";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { editPostById, submitNewPost } from "./post.helpers";
+
+export default function usePostMutation(postId?: string) {
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  const postQueryKey = ["post", postId];
+
+  const invalidatePost = () =>
+    queryClient.invalidateQueries({ queryKey: postQueryKey });
+
+  const createMutation = useMutation({
+    mutationFn: (newPost: CreatePostInput) => submitNewPost(newPost),
+    onSuccess: (newPostData) => {
+      const categoryOfNewPost = newPostData.data.category;
+      queryClient.invalidateQueries({
+        queryKey: ["community", categoryOfNewPost],
+      });
+      router.push(`/community/post/${newPostData.data.id}`);
+    },
+    onError: (error) => console.error(error, error.message),
+  });
+
+  const editMutation = useMutation({
+    mutationFn: (updatedPost: UpdatePostInput) =>
+      editPostById(postId!, updatedPost),
+    onSuccess: (data) => {
+      invalidatePost();
+      router.push(`/community/post/${postId}`);
+    },
+    onError: (error) => console.error(error, error.message),
+  });
+
+  return { createMutation, editMutation };
+}

--- a/src/components/domains/postDetail/PageClient.tsx
+++ b/src/components/domains/postDetail/PageClient.tsx
@@ -28,7 +28,6 @@ export default function PageClient({ postId }: { postId: string }) {
   if (!postDetail || !postStatus) {
     return <div>Loading...</div>;
   }
-
   const { content, ...postDetailHeader } = postDetail;
 
   return (

--- a/src/components/domains/postDetail/header/PostActions.tsx
+++ b/src/components/domains/postDetail/header/PostActions.tsx
@@ -38,7 +38,7 @@ export default function PostActions({
     {
       type: "edit",
       label: "수정",
-      onClick: () => {},
+      onClick: () => router.push(`/community/post/${postId}/edit`),
     },
     {
       type: "delete",

--- a/src/lib/hono/routes/v1/community.handler.ts
+++ b/src/lib/hono/routes/v1/community.handler.ts
@@ -178,6 +178,47 @@ authenticatedApi.openapi(createPostRoute, async (c) => {
   return apiCreated(c, result.data, "게시글을 성공적으로 생성했습니다.");
 });
 
+const editPostRoute = createRoute({
+  method: "patch",
+  path: "/posts/{id}",
+  summary: "커뮤니티 게시글 수정",
+  description: "커뮤니티 게시글 수정",
+  request: {
+    params: postIdParam,
+    body: {
+      content: {
+        "application/json": { schema: CommunitySchemas.UpdatePostInputSchema },
+      },
+    },
+  },
+  responses: createStandardApiResponses({
+    schema: CommunitySchemas.ApiPostResponseSchema,
+    description: "수정된 게시글",
+  }),
+  tags: ["Community"],
+});
+
+authenticatedApi.openapi(editPostRoute, async (c) => {
+  const { id } = c.req.valid("param");
+  const user = getAuthenticatedUser(c);
+
+  const result = await CommunityServices.updatePostService(
+    id,
+    user.id,
+    c.req.valid("json")
+  );
+  if (!result.success) {
+    return result.error === "NOT_FOUND"
+      ? apiNotFound(c, result.message)
+      : result.error === "BAD_REQUEST"
+      ? apiBadRequest(c, result.message)
+      : result.error === "FORBIDDEN"
+      ? apiForbidden(c, result.message)
+      : apiInternalError(c, result.message);
+  }
+  return apiSuccess(c, result.data, "게시글을 성공적으로 수정했습니다.");
+});
+
 const deletePostRoute = createRoute({
   method: "delete",
   path: "/posts/{id}",

--- a/src/lib/hono/schemas/community.schema.ts
+++ b/src/lib/hono/schemas/community.schema.ts
@@ -26,8 +26,6 @@ export const ApiPostResponseSchema = PostSchema.extend({
     nickname: true,
     imageUrl: true,
   }),
-  createdAt: z.string().datetime(),
-  updatedAt: z.string().datetime().nullable(),
 }).omit({
   userId: true,
 });

--- a/src/lib/hono/schemas/community.schema.ts
+++ b/src/lib/hono/schemas/community.schema.ts
@@ -92,3 +92,4 @@ export type PaginatedApiPostResponse = z.infer<
 export type GetPostsQuery = z.infer<typeof GetPostsQuerySchema>;
 export type CreatePostInput = z.infer<typeof CreatePostInputSchema>;
 export type UpdatePostInput = z.infer<typeof UpdatePostInputSchema>;
+export type PerfumeForPost = z.infer<typeof PerfumeForPostSchema>;

--- a/src/lib/hono/services/community.service.ts
+++ b/src/lib/hono/services/community.service.ts
@@ -1,6 +1,7 @@
 import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import type {
+  ApiPostDetailResponse,
   ApiPostStatusResponse,
   CreatePostInput,
   GetPostsQuery,
@@ -120,7 +121,7 @@ export async function getPaginatedPostListService(
 export async function getPostByIdService(
   id: string,
   userId?: string | null
-): Promise<ServiceResult<FullPost & { isAuthor: boolean }>> {
+): Promise<ServiceResult<ApiPostDetailResponse>> {
   try {
     const post = await prisma.$transaction(async (tx) => {
       await tx.post.update({
@@ -136,8 +137,19 @@ export async function getPostByIdService(
     if (!post) {
       return serviceNotFound("게시글을 찾을 수 없습니다.");
     }
+    const { perfumeMappings, ...restOfPost } = post;
+    const perfumes = perfumeMappings.map((mapping) => {
+      const perfumeImage = mapping.perfume.perfumeImage
+        ? { imageUrl: mapping.perfume.perfumeImage.imageUrl }
+        : null;
+
+      return {
+        ...mapping.perfume,
+        perfumeImage,
+      };
+    });
     const isAuthor = post.userId === userId;
-    return serviceSuccess({ ...post, isAuthor });
+    return serviceSuccess({ ...restOfPost, perfumes, isAuthor });
   } catch (error) {
     return serviceInternalError(error);
   }


### PR DESCRIPTION
### 📌요구사항

- [x] 게시글 수정 페이지 구현 및 api 연동

### 📌작업 진행 상황 (에러, 막혔던 부분, 그외 궁금한것 등등)

1.로그아웃 했을때 , 로그인한 상태에서 새로고침 시 게시글 수정 및 작성 페이지 처리 확인 필요 

게시글 작성, 수정페이지 남은 기능

게시글 임시 저장  

### 📌스크린샷 / 테스트결과 (선택)

https://github.com/user-attachments/assets/e126e855-124f-4c35-ac17-a15d69a47eef


### 📌이슈 번호
#76 