### PR TITLE
Feat: 향수 상세 페이지 모바일 차트 구현

### DIFF
--- a/src/components/domains/perfumeDetail/review/analytics/ReviewBarSection/BarChart/index.tsx
+++ b/src/components/domains/perfumeDetail/review/analytics/ReviewBarSection/BarChart/index.tsx
@@ -17,7 +17,7 @@ type BarChartProps = {
   data: {
     label: string;
     count: number;
-    color: string;
+    color?: string | undefined;
   }[];
 };
 

--- a/src/components/domains/perfumeDetail/review/analytics/ReviewDoughnutSection/DoughnutChart/index.tsx
+++ b/src/components/domains/perfumeDetail/review/analytics/ReviewDoughnutSection/DoughnutChart/index.tsx
@@ -9,7 +9,7 @@ type DoughnutChartProps = {
   data: {
     label: string;
     value: number;
-    color: string;
+    color?: string;
   }[];
   centerText?: string;
 };

--- a/src/components/domains/perfumeDetail/review/analytics/ReviewMobileSection/MobileBarChart/index.tsx
+++ b/src/components/domains/perfumeDetail/review/analytics/ReviewMobileSection/MobileBarChart/index.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+type BarListProps = {
+  data: {
+    label: string;
+    value: number;
+    color: string;
+  }[];
+  maxCap?: number;
+};
+
+const formatValue = (v: number, cap = 999) => (v > cap ? `${cap}+` : `${v}`);
+
+export function MobileBarChart({ data, maxCap = 999 }: BarListProps) {
+  const maxValue = Math.max(...data.map((d) => d.value), 1);
+
+  return (
+    <ul className="flex flex-col gap-2 w-full">
+      {data.map((item) => {
+        const isTop = item.value === maxValue;
+        const percent = Math.max(3, Math.round((item.value / maxValue) * 100));
+        const barColor = isTop ? item.color : "#D4D4D8";
+        const labelClass = isTop ? "text-black-100" : "text-gray-400";
+        const valueClass = isTop ? "text-black-100" : "text-gray-400";
+
+        return (
+          <li
+            key={item.label}
+            className="grid grid-cols-[auto_1fr_auto] items-center gap-3"
+          >
+            <span
+              className={`text-label-2 font-medium w-[79px] block ${labelClass}`}
+            >
+              {item.label}
+            </span>
+
+            <div className="relative h-2 rounded-full bg-gray-100 overflow-hidden">
+              <div
+                className="h-full rounded-full transition-[width]"
+                style={{ width: `${percent}%`, background: barColor }}
+              />
+            </div>
+
+            <span className={`text-label-3 font-medium ${valueClass}`}>
+              {formatValue(item.value, maxCap)}
+            </span>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/src/components/domains/perfumeDetail/review/analytics/ReviewMobileSection/index.tsx
+++ b/src/components/domains/perfumeDetail/review/analytics/ReviewMobileSection/index.tsx
@@ -1,75 +1,177 @@
-// import React from "react";
+"use client";
 
-// const mockData = [
-//   {
-//     category: "만족도",
-//     results: [
-//       { label: "최고예요", count: 87, color: "#6F4D3F" },
-//       { label: "좋아요", count: 65, color: "#A47764" },
-//       { label: "괜찮아요", count: 112, color: "#CB9C88" },
-//       { label: "별로예요", count: 29, color: "#DBC0B0" },
-//       { label: "싫어요", count: 43, color: "#EAD8C4" },
-//     ],
-//   },
-//   {
-//     category: "지속력",
-//     results: [
-//       { label: "긴 지속력 (6시간 이상)", count: 41, color: "#6F4D3F" },
-//       { label: "중간 (3-6시간)", count: 78, color: "#A47764" },
-//       { label: "짧음 (1-3시간)", count: 196, color: "#CB9C88" },
-//       { label: "매우 짧음 (1시간 미만)", count: 65, color: "#EAD8C4" },
-//     ],
-//   },
-//   {
-//     category: "가격",
-//     results: [
-//       { label: "가성비가 좋아요", count: 82, color: "#6F4D3F" },
-//       { label: "적당해요", count: 103, color: "#CB9C88" },
-//       { label: "비싸요", count: 138, color: "#EAD8C4" },
-//     ],
-//   },
-//   {
-//     category: "잔향",
-//     results: [
-//       { label: "멀리 퍼지는 향", count: 92, color: "#6F4D3F" },
-//       { label: "주변만 퍼지는 향", count: 118, color: "#CB9C88" },
-//       { label: "자기만 느끼는 향", count: 64, color: "#EAD8C4" },
-//     ],
-//   },
-//   {
-//     category: "이미지",
-//     results: [
-//       { label: "남성적인", value: 1, color: "#6F4D3F" },
-//       { label: "중성적인", value: 2, color: "#A47764" },
-//       { label: "여성적인", value: 3, color: "#EAD8C4" },
-//     ],
-//   },
-//   {
-//     category: "연령",
-//     results: [
-//       { label: "모든 연령대", value: 1000, color: "#6F4D3F" },
-//       { label: "성숙한 층", value: 181, color: "#A47764" },
-//       { label: "젊은 층", value: 51, color: "#EAD8C4" },
-//     ],
-//   },
-//   {
-//     category: "계절",
-//     results: [
-//       { label: "겨울", value: 1, color: "#6F4D3F" },
-//       { label: "가을", value: 2, color: "#A47764" },
-//       { label: "여름", value: 3, color: "#DBC0B0" },
-//       { label: "봄", value: 4, color: "#EAD8C4" },
-//     ],
-//   },
-//   {
-//     category: "시간",
-//     results: [
-//       { label: "밤", value: 500, color: "#6F4D3F" },
-//       { label: "낮", value: 51, color: "#EAD8C4" },
-//     ],
-//   },
-// ];
+import React, { useMemo, useState } from "react";
+import { countByCategory, type Counts } from "../analytics.helpers";
+import type { ReviewCategory } from "@/lib/types/review.types";
 
-// export default function ReviewMobileSection() {
-//   return <div>ReviewMobileSection</div>;
-// }
+export type BarDatum = { label: string; value: number };
+export type Block = { title: string; results: BarDatum[] };
+
+const MOBILE_CATEGORIES: ReviewCategory[] = [
+  "feeling",
+  "longevity",
+  "pricePerception",
+  "sillage",
+  "genderTone",
+  "season",
+  "timeOfDay",
+];
+
+/** 타이틀 매핑 */
+const TITLE_MAP: Record<ReviewCategory, string> = {
+  feeling: "만족도",
+  longevity: "지속력",
+  pricePerception: "가격",
+  sillage: "잔향",
+  genderTone: "이미지",
+  season: "계절",
+  timeOfDay: "시간",
+};
+
+function Caret({ open }: { open: boolean }) {
+  return (
+    <svg
+      aria-hidden
+      viewBox="0 0 24 24"
+      className={`h-5 w-5 transition-transform ${
+        open ? "-rotate-180" : "rotate-0"
+      }`}
+    >
+      <path
+        d="M7 10l5 5 5-5"
+        stroke="currentColor"
+        strokeWidth="2"
+        fill="none"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+type Winners = Set<BarDatum["label"]>;
+
+function MobileBarChart({
+  data,
+  winners,
+}: {
+  data: BarDatum[];
+  winners?: Winners;
+}) {
+  const total = data.reduce((a, b) => a + b.value, 0) || 1;
+
+  return (
+    <div className="mt-4 flex flex-col gap-3">
+      {data.map((d) => {
+        const pct = (d.value / total) * 100;
+        const isWinner = winners?.has(d.label) ?? false;
+
+        return (
+          <div
+            key={d.label}
+            className={`flex gap-3 items-center ${
+              isWinner ? "text-black-100" : ""
+            }`}
+            data-winner={isWinner ? "true" : "false"}
+          >
+            <div
+              className={`flex items-center justify-between w-[79px] text-label-3 font-medium whitespace-nowrap shrink-0
+                ${isWinner ? "text-black-100" : "text-gray-100"}`}
+            >
+              {d.label}
+            </div>
+
+            <div className="h-2 w-full rounded-full bg-gray-300">
+              <div
+                className={`h-2 rounded-full transition-[width] duration-300
+                  ${isWinner ? "bg-secondary" : "bg-gray-200"}`}
+                style={{ width: `${pct}%` }}
+              />
+            </div>
+
+            <span
+              className={`tabular-nums text-label-3 w-[31px] text-right
+                ${
+                  isWinner
+                    ? "font-semibold text-black-100"
+                    : "font-medium text-gray-100"
+                }`}
+            >
+              {d.value}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function MobileAnalyticsBlock({ block }: { block: Block }) {
+  const [open, setOpen] = useState(true);
+
+  const { winnersSet, winnerTop } = useMemo(() => {
+    const max = Math.max(0, ...block.results.map((r) => r.value));
+    const winners = block.results.filter((r) => r.value === max && max > 0);
+    return {
+      winnersSet: new Set(winners.map((w) => w.label)),
+      winnerTop: winners[0],
+    };
+  }, [block]);
+
+  return (
+    <li className="rounded-xl bg-white">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center gap-3"
+      >
+        <span className="shrink-0 rounded-md border border-black-100 px-3 py-2 text-label-1 font-medium text-black-100 w-[61px] whitespace-nowrap">
+          {block.title}
+        </span>
+
+        {winnerTop && (
+          <span className="text-label-1 text-black-100">{winnerTop.label}</span>
+        )}
+
+        <span className="h-[1px] grow border-b border-dashed border-gray-200" />
+
+        <div className="flex gap-1">
+          {winnerTop && (
+            <span className="shrink-0 tabular-nums text-label-1 font-medium text-black-100">
+              {winnerTop.value}
+            </span>
+          )}
+          <Caret open={open} />
+        </div>
+      </button>
+
+      {open && (
+        <div className="px-2">
+          <MobileBarChart data={block.results} winners={winnersSet} />
+        </div>
+      )}
+    </li>
+  );
+}
+
+export default function ReviewMobileSection({ counts }: { counts: Counts }) {
+  const blocks = useMemo(() => {
+    return MOBILE_CATEGORIES.map((cat) => {
+      const rows = countByCategory(counts, cat);
+      return {
+        title: TITLE_MAP[cat],
+        results: rows.map((r) => ({ label: r.label, value: r.count })),
+      };
+    });
+  }, [counts]);
+
+  return (
+    <section>
+      <ul className="flex flex-col gap-[18px] px-4">
+        {blocks.map((block) => (
+          <MobileAnalyticsBlock key={block.title} block={block} />
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/domains/perfumeDetail/review/analytics/ReviewMobileSection/index.tsx
+++ b/src/components/domains/perfumeDetail/review/analytics/ReviewMobileSection/index.tsx
@@ -5,7 +5,11 @@ import { countByCategory, type Counts } from "../analytics.helpers";
 import type { ReviewCategory } from "@/lib/types/review.types";
 
 export type BarDatum = { label: string; value: number };
-export type Block = { title: string; results: BarDatum[] };
+export type Block = {
+  title: string;
+  category: ReviewCategory;
+  results: BarDatum[];
+};
 
 const MOBILE_CATEGORIES: ReviewCategory[] = [
   "feeling",
@@ -27,6 +31,64 @@ const TITLE_MAP: Record<ReviewCategory, string> = {
   season: "계절",
   timeOfDay: "시간",
 };
+
+/* -------------------- 라벨 포맷터 -------------------- */
+
+function normLongevity(
+  label: string
+): "LONG" | "MODERATE" | "WEAK" | "VERY_WEAK" | null {
+  const s = label.trim();
+
+  if (s === "긴 지속력 (6시간 이상)") return "LONG";
+  if (s === "중간 (3-6시간)") return "MODERATE";
+  if (s === "짧음 (1-3시간)") return "WEAK";
+  if (s === "매우 짧음 (1시간 미만)") return "VERY_WEAK";
+
+  return null;
+}
+function normSillage(label: string): "STRONG" | "MODERATE" | "INTIMATE" | null {
+  const s = label.trim();
+
+  if (s === "주변 사람들이 쉽게 느낄 수 있는 정도") return "STRONG";
+  if (s === "가까이 있는 사람이 느낄 수 있는 정도") return "MODERATE";
+  if (s === "자신만 느낄 수 있는 정도") return "INTIMATE";
+  return null;
+}
+
+function formatLongevity(label: string): string {
+  switch (normLongevity(label)) {
+    case "LONG":
+      return "긴 지속력 (6h)";
+    case "MODERATE":
+      return "중간 (3-6h)";
+    case "WEAK":
+      return "짧음 (1-3h)";
+    case "VERY_WEAK":
+      return "매우 짧음 (1h)";
+    default:
+      return label;
+  }
+}
+function formatSillage(label: string): string {
+  switch (normSillage(label)) {
+    case "STRONG":
+      return "멀리 퍼지는 향";
+    case "MODERATE":
+      return "주변만 퍼지는 향";
+    case "INTIMATE":
+      return "자기만 느끼는 향";
+    default:
+      return label;
+  }
+}
+
+function formatLabel(category: ReviewCategory, label: string): string {
+  if (category === "longevity") return formatLongevity(label);
+  if (category === "sillage") return formatSillage(label);
+  return label;
+}
+
+/* -------------------- UI -------------------- */
 
 function Caret({ open }: { open: boolean }) {
   return (
@@ -52,9 +114,11 @@ function Caret({ open }: { open: boolean }) {
 type Winners = Set<BarDatum["label"]>;
 
 function MobileBarChart({
+  category,
   data,
   winners,
 }: {
+  category: ReviewCategory;
   data: BarDatum[];
   winners?: Winners;
 }) {
@@ -78,24 +142,24 @@ function MobileBarChart({
               className={`flex items-center justify-between w-[79px] text-label-3 font-medium whitespace-nowrap shrink-0
                 ${isWinner ? "text-black-100" : "text-gray-100"}`}
             >
-              {d.label}
+              {formatLabel(category, d.label)}
             </div>
 
             <div className="h-2 w-full rounded-full bg-gray-300">
               <div
-                className={`h-2 rounded-full transition-[width] duration-300
-                  ${isWinner ? "bg-secondary" : "bg-gray-200"}`}
+                className={`h-2 rounded-full transition-[width] duration-300 ${
+                  isWinner ? "bg-secondary" : "bg-gray-200"
+                }`}
                 style={{ width: `${pct}%` }}
               />
             </div>
 
             <span
-              className={`tabular-nums text-label-3 w-[31px] text-right
-                ${
-                  isWinner
-                    ? "font-semibold text-black-100"
-                    : "font-medium text-gray-100"
-                }`}
+              className={`tabular-nums text-label-3 w-[31px] text-right ${
+                isWinner
+                  ? "font-semibold text-black-100"
+                  : "font-medium text-gray-100"
+              }`}
             >
               {d.value}
             </span>
@@ -130,7 +194,9 @@ function MobileAnalyticsBlock({ block }: { block: Block }) {
         </span>
 
         {winnerTop && (
-          <span className="text-label-1 text-black-100">{winnerTop.label}</span>
+          <span className="text-label-1 text-black-100">
+            {formatLabel(block.category, winnerTop.label)}
+          </span>
         )}
 
         <span className="h-[1px] grow border-b border-dashed border-gray-200" />
@@ -147,7 +213,11 @@ function MobileAnalyticsBlock({ block }: { block: Block }) {
 
       {open && (
         <div className="px-2">
-          <MobileBarChart data={block.results} winners={winnersSet} />
+          <MobileBarChart
+            category={block.category}
+            data={block.results}
+            winners={winnersSet}
+          />
         </div>
       )}
     </li>
@@ -155,11 +225,12 @@ function MobileAnalyticsBlock({ block }: { block: Block }) {
 }
 
 export default function ReviewMobileSection({ counts }: { counts: Counts }) {
-  const blocks = useMemo(() => {
+  const blocks: Block[] = useMemo(() => {
     return MOBILE_CATEGORIES.map((cat) => {
       const rows = countByCategory(counts, cat);
       return {
         title: TITLE_MAP[cat],
+        category: cat,
         results: rows.map((r) => ({ label: r.label, value: r.count })),
       };
     });

--- a/src/components/domains/perfumeDetail/review/analytics/analytics.helpers.ts
+++ b/src/components/domains/perfumeDetail/review/analytics/analytics.helpers.ts
@@ -1,32 +1,39 @@
 import { ApiReviewResponse } from "@/lib/hono/schemas/review.schema";
 import { ATTRIBUTE_ID_MAP, CATEGORY_LABEL_MAP } from "./analytics.constants";
-import { ReviewCategory } from "@/lib/types/review.types";
+import type { ReviewCategory } from "@/lib/types/review.types";
 
-type AttributeId = number;
-type OptionKey = string;
-type Counts = Record<AttributeId, Record<OptionKey, number>>;
+export type AttributeId = number;
+export type OptionKey = string;
+export type Counts = Record<AttributeId, Record<OptionKey, number>>;
 
 export const calculateReviewCounts = (data: ApiReviewResponse[]): Counts => {
   const counts: Counts = {};
 
   data.forEach((review) => {
     review.attributeSelections.forEach((selection) => {
-      const { attributeId, value } = selection.option;
+      const attributeId = selection.option.attributeId as AttributeId;
+      const optionKey = String(selection.option.value) as OptionKey;
+
       if (!counts[attributeId]) {
         counts[attributeId] = {};
       }
-      counts[attributeId][value] = (counts[attributeId][value] || 0) + 1;
+      counts[attributeId][optionKey] =
+        (counts[attributeId][optionKey] || 0) + 1;
     });
   });
 
   return counts;
 };
 
-export const countByCategory = (counts: Counts, category: ReviewCategory) => {
+export const countByCategory = (
+  counts: Counts,
+  category: ReviewCategory
+): Array<{ key: string; label: string; count: number; color?: string }> => {
   const attributeId = ATTRIBUTE_ID_MAP[category];
   const categoryCounts = counts[attributeId] || {};
 
   return CATEGORY_LABEL_MAP[category].map(({ key, label, color }) => ({
+    key,
     label,
     count: categoryCounts[key] || 0,
     color,

--- a/src/components/domains/perfumeDetail/review/analytics/index.tsx
+++ b/src/components/domains/perfumeDetail/review/analytics/index.tsx
@@ -10,6 +10,7 @@ import { ReviewModal } from "@/components/modal/reviewModal";
 import { useUserStore } from "@/lib/stores/useUserStore";
 import { calculateReviewCounts } from "./analytics.helpers";
 import { ReviewAnalyticsProps } from "../review.type";
+import ReviewMobileSection from "./ReviewMobileSection";
 // TODO: 리뷰 수정 기능 검토
 export const ReviewAnalytics = ({ data }: ReviewAnalyticsProps) => {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
@@ -26,7 +27,7 @@ export const ReviewAnalytics = ({ data }: ReviewAnalyticsProps) => {
         <ReviewBarSection counts={counts} />
       </section>
       <section className="tablet:hidden">
-        {/* <ReviewMobileSection /> */}
+        <ReviewMobileSection counts={counts} />
       </section>
       <section className="hidden tablet:block w-60 self-center">
         <div className="text-gray-100 text-label-2 font-medium text-center pb-2">

--- a/src/lib/types/perfumeReview.d.ts
+++ b/src/lib/types/perfumeReview.d.ts
@@ -1,0 +1,42 @@
+export type UUID = string;
+
+export type TUsageStatus = "CURRENTLY_USING" | "USED_BEFORE" | "NOT_USED_YET";
+
+export type TFeeling = "BEST" | "GOOD" | "NEUTRAL" | "BAD" | "DISLIKE";
+export type TLongevity = "VERY_WEAK" | "WEAK" | "MODERATE" | "LONG_LASTING";
+export type TSillage = "INTIMATE" | "MODERATE" | "STRONG";
+export type TGenderTone = "FEMININE" | "UNISEX" | "MASCULINE";
+export type TSeason = "SPRING" | "SUMMER" | "AUTUMN" | "WINTER";
+export type TTimeOfDay = "DAY" | "NIGHT";
+export type TPricePerception = "EXPENSIVE" | "REASONABLE" | "GOOD_VALUE";
+
+export interface IReviewAuthor {
+  id: UUID;
+  nickname: string;
+  imageUrl: string | null;
+}
+
+export interface IReviewChips {
+  feeling: TFeeling;
+  longevity: TLongevity;
+  sillage: TSillage;
+  genderTone: TGenderTone;
+  season: TSeason[];
+  timeOfDay: TTimeOfDay;
+  pricePerception: TPricePerception;
+}
+
+export interface IReviewItem {
+  id: UUID;
+  usageStatus: TUsageStatus;
+  content: string;
+  createdAt: string;
+  author: IReviewAuthor;
+  chips: IReviewChips;
+}
+
+export interface IReviewsResponse {
+  success: boolean;
+  message: string;
+  data: IReviewItem[];
+}


### PR DESCRIPTION
### 📌요구사항

- [x] 향수 상세 페이지 모바일 차트 구현

### 📌작업 진행 상황 (에러, 막혔던 부분, 그외 궁금한것 등등)

### 📌스크린샷 / 테스트결과 (선택)
<img width="343" height="726" alt="image" src="https://github.com/user-attachments/assets/bf070b7d-1a3b-46be-b130-3d7ba14f3554" />


### 📌이슈 번호
